### PR TITLE
Security: restrict Open5GS MongoDB host exposure

### DIFF
--- a/open5gs/docker-compose.yml
+++ b/open5gs/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - mongodb-data:/data/db
       - mongodb-config:/data/configdb
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 10s


### PR DESCRIPTION
## Finding
`open5gs/docker-compose.yml` publishes MongoDB as `27017:27017`, exposing the subscriber database on every host interface when the stack is launched. Internal Open5GS services already use the private Compose network (`mongodb:27017`), so this host-wide bind is not required for service-to-service traffic.

## Fix
Bind the optional host mapping to loopback only: `127.0.0.1:27017:27017`.

This keeps local administrative access available while preventing LAN/Internet reachability through the Docker host binding. It does not change the internal Compose hostname or port used by the controller and Open5GS services.

## Verification
Source/config retest confirms the branch no longer contains the all-interface MongoDB host mapping. No database connection, subscriber data, or production host was accessed.

Related broader control-plane remediation: #15.