### PR TITLE
QA: verify every DarCloud page and internal link

### DIFF
--- a/.github/workflows/darcloud-live-smoke.yml
+++ b/.github/workflows/darcloud-live-smoke.yml
@@ -1,0 +1,58 @@
+name: DarCloud live page smoke
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: darcloud-live-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser-smoke:
+    name: Browser and link audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install project dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Install Playwright test runtime
+        run: |
+          npm install --no-save --ignore-scripts playwright
+          npx playwright install --with-deps chromium
+
+      - name: Run read-only DarCloud audit
+        id: smoke
+        continue-on-error: true
+        run: node scripts/darcloud-live-smoke.mjs
+
+      - name: Publish audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: darcloud-live-smoke-report
+          path: artifacts/darcloud-smoke/
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Enforce audit result
+        if: steps.smoke.outcome != 'success'
+        run: |
+          echo "DarCloud live-page smoke audit failed. See the uploaded report."
+          exit 1

--- a/.github/workflows/darcloud-live-smoke.yml
+++ b/.github/workflows/darcloud-live-smoke.yml
@@ -35,18 +35,21 @@ jobs:
       - name: TypeScript check
         run: npx tsc --noEmit
 
-      - name: Run complete test suite
+      - name: Run complete internal Worker test suite
         run: npx vitest run --config tests/vitest.config.mts
 
-      - name: Compile Cloudflare Worker without deploying
-        run: npx wrangler deploy --dry-run --outdir artifacts/wrangler-dry-run
+      - name: Run isolated public Worker security and page tests
+        run: npx vitest run --config tests/vitest.public.config.mts
 
-      - name: Publish dry-run bundle metadata
+      - name: Compile isolated public Cloudflare Worker without deploying
+        run: npx wrangler deploy --config wrangler.public.jsonc --dry-run --outdir artifacts/wrangler-public-dry-run
+
+      - name: Publish public Worker dry-run metadata
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: darcloud-worker-dry-run
-          path: artifacts/wrangler-dry-run/
+          name: darcloud-public-worker-dry-run
+          path: artifacts/wrangler-public-dry-run/
           if-no-files-found: warn
           retention-days: 14
 

--- a/.github/workflows/darcloud-live-smoke.yml
+++ b/.github/workflows/darcloud-live-smoke.yml
@@ -54,6 +54,7 @@ jobs:
           retention-days: 14
 
   browser-smoke:
+    if: github.event_name == 'workflow_dispatch'
     name: Browser and link audit
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/darcloud-live-smoke.yml
+++ b/.github/workflows/darcloud-live-smoke.yml
@@ -1,4 +1,4 @@
-name: DarCloud live page smoke
+name: DarCloud release validation
 
 on:
   pull_request:
@@ -10,10 +10,46 @@ permissions:
   contents: read
 
 concurrency:
-  group: darcloud-live-smoke-${{ github.ref }}
+  group: darcloud-release-validation-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  source-contract:
+    name: Worker build and test contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install project dependencies
+        run: npm ci
+
+      - name: TypeScript check
+        run: npx tsc --noEmit
+
+      - name: Run complete test suite
+        run: npx vitest run --config tests/vitest.config.mts
+
+      - name: Compile Cloudflare Worker without deploying
+        run: npx wrangler deploy --dry-run --outdir artifacts/wrangler-dry-run
+
+      - name: Publish dry-run bundle metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: darcloud-worker-dry-run
+          path: artifacts/wrangler-dry-run/
+          if-no-files-found: warn
+          retention-days: 14
+
   browser-smoke:
     name: Browser and link audit
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,42 @@
-name: QuranChain™ Deploy
+name: DarCloud verified deploy
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    name: Deploy to Cloudflare Workers
-    steps:
-      - uses: actions/checkout@v4
+permissions:
+  contents: read
 
-      - name: Setup Node.js
+concurrency:
+  group: darcloud-production
+  cancel-in-progress: false
+
+jobs:
+  validate-and-deploy:
+    name: Validate, deploy, and verify DarCloud
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: npm
+
+      - name: Verify deployment credentials are configured
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$CLOUDFLARE_API_TOKEN" || { echo "CLOUDFLARE_API_TOKEN is not configured"; exit 1; }
+          test -n "$CLOUDFLARE_ACCOUNT_ID" || { echo "CLOUDFLARE_ACCOUNT_ID is not configured"; exit 1; }
 
       - name: Install dependencies
         run: npm ci
@@ -24,26 +44,23 @@ jobs:
       - name: TypeScript check
         run: npx tsc --noEmit
 
-      - name: Run tests
-        run: npx vitest run --config tests/vitest.config.mts 2>/dev/null || echo "Tests skipped (no test DB in CI)"
+      - name: Run complete test suite
+        run: npx vitest run --config tests/vitest.config.mts
 
-      - name: Apply D1 Migrations
-        run: echo "y" | npx wrangler d1 migrations apply DB --remote
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Compile Cloudflare Worker without deploying
+        run: npx wrangler deploy --dry-run --outdir artifacts/wrangler-dry-run
 
       - name: Deploy Worker
         run: npx wrangler deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
-      - name: Verify deployment
-        run: |
-          sleep 5
-          WORKER_URL="https://quranchain1.$(echo ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} | head -c 8).workers.dev"
-          echo "Deployed to Cloudflare Workers"
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Verify every DarCloud production page
+        run: node scripts/darcloud-post-deploy-check.mjs
+
+      - name: Publish dry-run bundle metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: darcloud-production-dry-run
+          path: artifacts/wrangler-dry-run/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
   validate-and-deploy:
     name: Validate, deploy, and verify DarCloud
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -44,23 +44,36 @@ jobs:
       - name: TypeScript check
         run: npx tsc --noEmit
 
-      - name: Run complete test suite
+      - name: Run internal Worker test suite
         run: npx vitest run --config tests/vitest.config.mts
 
-      - name: Compile Cloudflare Worker without deploying
-        run: npx wrangler deploy --dry-run --outdir artifacts/wrangler-dry-run
+      - name: Run isolated public Worker page and security suite
+        run: npx vitest run --config tests/vitest.public.config.mts
 
-      - name: Deploy Worker
-        run: npx wrangler deploy
+      - name: Compile isolated public Worker without deploying
+        run: npx wrangler deploy --config wrangler.public.jsonc --dry-run --outdir artifacts/wrangler-public-dry-run
 
-      - name: Verify every DarCloud production page
+      - name: Deploy isolated public Worker
+        run: npx wrangler deploy --config wrangler.public.jsonc
+
+      - name: Verify every declared production route
         run: node scripts/darcloud-post-deploy-check.mjs
 
-      - name: Publish dry-run bundle metadata
+      - name: Install Playwright browser runtime
+        run: |
+          npm install --no-save --ignore-scripts playwright
+          npx playwright install --with-deps chromium
+
+      - name: Run full browser, console, request, and internal-link audit
+        run: node scripts/darcloud-live-smoke.mjs
+
+      - name: Publish release evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: darcloud-production-dry-run
-          path: artifacts/wrangler-dry-run/
+          name: darcloud-production-verification
+          path: |
+            artifacts/wrangler-public-dry-run/
+            artifacts/darcloud-smoke/
           if-no-files-found: warn
           retention-days: 14

--- a/landing-pages/darcloud-referral.js
+++ b/landing-pages/darcloud-referral.js
@@ -1,0 +1,90 @@
+const PAGE = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>DarCloud Affiliate Program | Referral Partnerships</title>
+  <meta name="description" content="Join the DarCloud affiliate and referral partnership program.">
+  <style>
+    :root{color-scheme:dark;background:#060912;color:#edf4ff;font-family:Inter,ui-sans-serif,system-ui,sans-serif}
+    *{box-sizing:border-box}body{margin:0;min-height:100vh;background:radial-gradient(circle at 20% 10%,#15304b 0,transparent 36%),linear-gradient(180deg,#07101c,#060912)}
+    a{color:inherit}.shell{width:min(1120px,calc(100% - 2rem));margin:auto}.nav{display:flex;align-items:center;justify-content:space-between;padding:1.25rem 0;border-bottom:1px solid #24344d}
+    .brand{font-weight:900;letter-spacing:.04em}.navlinks{display:flex;gap:1rem;align-items:center;flex-wrap:wrap}.navlinks a{text-decoration:none;color:#b8c6d9}
+    .hero{padding:6rem 0 4rem;display:grid;grid-template-columns:minmax(0,1.25fr) minmax(280px,.75fr);gap:2rem;align-items:center}.eyebrow{color:#67e8f9;text-transform:uppercase;letter-spacing:.16em;font-weight:800;font-size:.78rem}
+    h1{font-size:clamp(2.6rem,7vw,5.6rem);line-height:.96;margin:.8rem 0 1.2rem}.lead{font-size:1.15rem;line-height:1.75;color:#b7c4d6;max-width:720px}.actions{display:flex;gap:.8rem;flex-wrap:wrap;margin-top:2rem}
+    .button{display:inline-flex;padding:.85rem 1.15rem;border-radius:11px;text-decoration:none;font-weight:800;border:1px solid #2f4765}.button.primary{background:#67e8f9;color:#04111a;border-color:#67e8f9}
+    .card,.step{background:rgba(12,24,39,.88);border:1px solid #2b3f59;border-radius:18px;padding:1.4rem;box-shadow:0 20px 60px rgba(0,0,0,.22)}.card h2,.step h2{margin-top:0}.metric{display:flex;justify-content:space-between;gap:1rem;padding:.9rem 0;border-bottom:1px solid #25354b}.metric:last-child{border:0}
+    .steps{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem;padding:0 0 5rem}.num{display:inline-grid;place-items:center;width:2.2rem;height:2.2rem;border-radius:50%;background:#173753;color:#67e8f9;font-weight:900}.step p,.fine{color:#9eafc5;line-height:1.65}
+    footer{border-top:1px solid #24344d;padding:2rem 0;color:#8495aa;display:flex;justify-content:space-between;gap:1rem;flex-wrap:wrap}
+    @media(max-width:760px){.hero{grid-template-columns:1fr;padding-top:3.5rem}.steps{grid-template-columns:1fr}.nav{align-items:flex-start;gap:1rem}.navlinks{justify-content:flex-end}}
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <nav class="nav" aria-label="Primary navigation">
+      <a class="brand" href="https://www.darcloud.host/">DarCloud</a>
+      <div class="navlinks">
+        <a href="https://www.darcloud.host/#services">Services</a>
+        <a href="https://darcloud.host/terms">Terms</a>
+        <a href="https://darcloud.host/login">Sign In</a>
+      </div>
+    </nav>
+
+    <main>
+      <section class="hero">
+        <div>
+          <div class="eyebrow">Affiliate · Referral Partnerships</div>
+          <h1>Grow with the DarCloud ecosystem.</h1>
+          <p class="lead">Refer qualified customers to DarCloud services through an approved partnership. Commission eligibility, attribution windows, payment timing, and campaign restrictions are governed by the terms shown in your approved affiliate agreement.</p>
+          <div class="actions">
+            <a class="button primary" href="https://darcloud.host/signup">Create a DarCloud account</a>
+            <a class="button" href="https://www.darcloud.host/#contact">Contact partnerships</a>
+          </div>
+        </div>
+        <aside class="card" aria-label="Affiliate program overview">
+          <h2>Partner safeguards</h2>
+          <div class="metric"><span>Attribution</span><strong>Server recorded</strong></div>
+          <div class="metric"><span>Commission</span><strong>Per approved terms</strong></div>
+          <div class="metric"><span>Payments</span><strong>Verified conversions only</strong></div>
+          <div class="metric"><span>Prohibited</span><strong>Spam or misleading claims</strong></div>
+        </aside>
+      </section>
+
+      <section class="steps" aria-label="How the affiliate program works">
+        <article class="step"><span class="num">1</span><h2>Apply</h2><p>Create an account and contact the DarCloud partnerships team with your audience, channel, and intended campaign.</p></article>
+        <article class="step"><span class="num">2</span><h2>Receive approval</h2><p>Use only the referral materials, claims, destination links, and commission terms approved for your partnership.</p></article>
+        <article class="step"><span class="num">3</span><h2>Earn on verified conversions</h2><p>Eligible commission is calculated only after the customer action and payment status are verified by DarCloud systems.</p></article>
+      </section>
+      <p class="fine">This page does not promise a specific commission rate or payout. Final terms are established in the approved partner agreement.</p>
+    </main>
+
+    <footer>
+      <span>© 2026 DarCloud</span>
+      <span><a href="https://darcloud.host/privacy">Privacy</a> · <a href="https://darcloud.host/terms">Terms</a></span>
+    </footer>
+  </div>
+</body>
+</html>`;
+
+function json(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json;charset=UTF-8", "cache-control": "no-store" },
+  });
+}
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return json({ error: "Method not allowed" }, 405);
+    }
+    if (url.pathname === "/health") {
+      return json({ status: "healthy", service: "darcloud-referral" });
+    }
+    if (url.pathname !== "/") return json({ error: "Not found" }, 404);
+    return new Response(request.method === "HEAD" ? null : PAGE, {
+      headers: { "content-type": "text/html;charset=UTF-8", "cache-control": "public, max-age=300" },
+    });
+  },
+};

--- a/landing-pages/darcloud-revenue.js
+++ b/landing-pages/darcloud-revenue.js
@@ -2,7 +2,7 @@
 var CORS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-DarPay-Signature"
+  "Access-Control-Allow-Headers": "Content-Type, Authorization, X-DarPay-Signature, Stripe-Signature"
 };
 var FOUNDER_ROYALTY_RATE = 0.3;
 var REVENUE_DISTRIBUTION = {
@@ -12,6 +12,49 @@ var REVENUE_DISTRIBUTION = {
   ecosystem: 0.18,
   zakat: 0.02
 };
+var STRIPE_SIGNATURE_TOLERANCE_SECONDS = 300;
+
+function constantTimeEqual(a, b) {
+  if (a.length !== b.length)
+    return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++)
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+async function verifyStripeSignature(request, webhookSecret, rawBody) {
+  if (!webhookSecret)
+    return false;
+  const signatureHeader = request.headers.get("Stripe-Signature") || "";
+  const parts = signatureHeader.split(",").map((part) => part.trim());
+  const timestampPart = parts.find((part) => part.startsWith("t="));
+  const v1Signatures = parts.filter((part) => part.startsWith("v1=")).map((part) => part.slice(3).toLowerCase());
+  if (!timestampPart || v1Signatures.length === 0)
+    return false;
+  const timestamp = Number(timestampPart.slice(2));
+  if (!Number.isFinite(timestamp))
+    return false;
+  const age = Math.abs(Math.floor(Date.now() / 1e3) - timestamp);
+  if (age > STRIPE_SIGNATURE_TOLERANCE_SECONDS)
+    return false;
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(webhookSecret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signed = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    encoder.encode(`${timestamp}.${rawBody}`)
+  );
+  const expected = Array.from(new Uint8Array(signed)).map((b) => b.toString(16).padStart(2, "0")).join("");
+  return v1Signatures.some((candidate) => constantTimeEqual(candidate, expected));
+}
+
 var src_default = {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -70,14 +113,24 @@ var src_default = {
       });
     }
     if (url.pathname === "/api/webhooks/stripe" && request.method === "POST") {
+      const rawBody = await request.text();
+      const webhookSecret = env?.STRIPE_WEBHOOK_SECRET || "";
+      const signatureValid = await verifyStripeSignature(request, webhookSecret, rawBody);
+      if (!signatureValid) {
+        return json({ error: "Invalid webhook signature" }, 400);
+      }
       try {
-        const body = await request.json();
+        const body = JSON.parse(rawBody);
         const eventType = body.type || "unknown";
+        const stripeSignature = request.headers.get("Stripe-Signature") || "";
         ctx.waitUntil(
           fetch("https://revenue.darcloud.host/webhooks/stripe", {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(body)
+            headers: {
+              "Content-Type": "application/json",
+              "Stripe-Signature": stripeSignature
+            },
+            body: rawBody
           }).catch(() => {
           })
         );

--- a/scripts/darcloud-live-smoke.mjs
+++ b/scripts/darcloud-live-smoke.mjs
@@ -1,0 +1,325 @@
+import { chromium } from "playwright";
+import { mkdir, writeFile } from "node:fs/promises";
+
+const OUTPUT_DIR = "artifacts/darcloud-smoke";
+const NAVIGATION_TIMEOUT_MS = 30_000;
+const SETTLE_MS = 1_500;
+const MAX_LINKS = 250;
+
+const pageChecks = [
+  { name: "www home", url: "https://www.darcloud.host/", markers: ["DarCloud Empire"] },
+  { name: "AI", url: "https://ai.darcloud.host/", markers: ["AI", "Assistant"] },
+  { name: "API gateway", url: "https://api-gateway.darcloud.host/", markers: ["API", "Gateway"] },
+  { name: "blockchain", url: "https://blockchain.darcloud.host/", markers: ["Blockchain", "QuranChain"] },
+  { name: "checkout", url: "https://checkout.darcloud.host/", markers: ["Checkout", "Payment", "Plans"] },
+  { name: "commerce", url: "https://commerce.darcloud.host/", markers: ["Commerce", "Marketplace"] },
+  { name: "DeFi", url: "https://defi.darcloud.host/", markers: ["DeFi", "Finance"] },
+  { name: "education", url: "https://edu.darcloud.host/", markers: ["Education", "Learning"] },
+  { name: "energy", url: "https://energy.darcloud.host/", markers: ["Energy", "Grid"] },
+  { name: "health", url: "https://health.darcloud.host/", markers: ["Health", "Care"] },
+  { name: "HR", url: "https://hr.darcloud.host/", markers: ["Human", "HR", "Workforce"] },
+  { name: "law", url: "https://law.darcloud.host/", markers: ["Law", "Legal"] },
+  { name: "media", url: "https://media.darcloud.host/", markers: ["Media", "Content"] },
+  { name: "community", url: "https://community.darcloud.host/", markers: ["Community", "Dar Al-Nas"] },
+  { name: "Dar Al-Nas alias", url: "https://darnas.darcloud.host/", markers: ["Dar Al-Nas", "Community"] },
+  { name: "pay", url: "https://pay.darcloud.host/", markers: ["Pay", "Payment"] },
+  { name: "security", url: "https://security.darcloud.host/", markers: ["Security", "Protection"] },
+  { name: "telecom", url: "https://telecom.darcloud.host/", markers: ["Telecom", "Network"] },
+  { name: "trade", url: "https://trade.darcloud.host/", markers: ["Trade", "Commerce"] },
+  { name: "transport", url: "https://transport.darcloud.host/", markers: ["Transport", "Mobility"] },
+  { name: "enterprise", url: "https://enterprise.darcloud.host/", markers: ["Enterprise", "Business"] },
+  { name: "HWC", url: "https://hwc.darcloud.host/", markers: ["Wealth", "HWC"] },
+  { name: "HWC alias", url: "https://halalwealthclub.darcloud.host/", markers: ["Wealth", "HWC"] },
+  { name: "mesh", url: "https://mesh.darcloud.host/", markers: ["Mesh", "Network"] },
+  { name: "MeshTalk", url: "https://meshtalk.darcloud.host/", markers: ["MeshTalk", "Fungi"] },
+  { name: "FungiOS alias", url: "https://fungios.darcloud.host/", markers: ["MeshTalk", "Fungi"] },
+  { name: "real estate", url: "https://realestate.darcloud.host/", markers: ["Real Estate", "Property"] },
+  { name: "revenue", url: "https://revenue.darcloud.host/", markers: ["Revenue", "Affiliate", "Income"] },
+  { name: "Omar AI", url: "https://omarai.darcloud.host/", markers: ["Omar AI", "Assistant"] },
+  { name: "affiliate", url: "https://referral.darcloud.host/", markers: ["Affiliate", "Commission"] },
+
+  { name: "signup", url: "https://darcloud.host/signup", markers: ["Sign Up", "Create"] },
+  { name: "login", url: "https://darcloud.host/login", markers: ["Login", "Sign In"] },
+  { name: "onboarding", url: "https://darcloud.host/onboarding", markers: ["Onboarding", "Welcome", "Setup"] },
+  { name: "dashboard", url: "https://darcloud.host/dashboard", markers: ["Dashboard", "Login", "Sign In"] },
+  { name: "admin", url: "https://darcloud.host/admin", markers: ["Admin", "Login", "Sign In"] },
+  { name: "checkout success", url: "https://darcloud.host/checkout/success", markers: ["Success", "Payment", "Checkout"] },
+  { name: "checkout cancel", url: "https://darcloud.host/checkout/cancel", markers: ["Cancel", "Checkout", "Payment"] },
+  { name: "checkout plan", url: "https://darcloud.host/checkout/pro", markers: ["Checkout", "DarCloud Professional", "Pro"] },
+  { name: "privacy", url: "https://darcloud.host/privacy", markers: ["Privacy"] },
+  { name: "privacy alias", url: "https://darcloud.host/privacy-policy", markers: ["Privacy"] },
+  { name: "terms", url: "https://darcloud.host/terms", markers: ["Terms"] },
+];
+
+const forbiddenBodyMarkers = [
+  "Loading platform...",
+  "Application error: a client-side exception has occurred",
+  "Internal Server Error",
+  "Error 1101",
+  "This deployment is temporarily unavailable",
+];
+
+function isDarCloudHost(hostname) {
+  return hostname === "darcloud.host" || hostname.endsWith(".darcloud.host");
+}
+
+function shouldCheckLink(url) {
+  if (!isDarCloudHost(url.hostname)) return false;
+  if (!/^https?:$/.test(url.protocol)) return false;
+  if (url.pathname.startsWith("/api/")) return false;
+  if (url.pathname === "/logout") return false;
+  if (/\b(delete|remove|revoke|terminate)\b/i.test(url.pathname)) return false;
+  return true;
+}
+
+async function fetchManual(url) {
+  const response = await fetch(url, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(NAVIGATION_TIMEOUT_MS),
+    headers: { "user-agent": "DarCloud-QA-Smoke/1.0" },
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    location: response.headers.get("location") || "",
+    contentType: response.headers.get("content-type") || "",
+    text,
+  };
+}
+
+async function checkApexRedirect() {
+  const result = {
+    name: "apex redirect",
+    url: "https://darcloud.host/",
+    passed: false,
+    errors: [],
+    warnings: [],
+  };
+
+  try {
+    const response = await fetchManual(result.url);
+    result.status = response.status;
+    result.location = response.location;
+    result.title = "";
+    if (![301, 302, 307, 308].includes(response.status)) {
+      result.errors.push(`expected an HTTP redirect, received ${response.status}`);
+    }
+    if (response.location && new URL(response.location, result.url).href !== "https://www.darcloud.host/") {
+      result.errors.push(`expected redirect to https://www.darcloud.host/, received ${response.location}`);
+    }
+    if (!response.location) {
+      result.errors.push("redirect response did not include a Location header");
+    }
+    result.passed = result.errors.length === 0;
+  } catch (error) {
+    result.errors.push(String(error));
+  }
+  return result;
+}
+
+async function checkPage(browser, check, discoveredLinks) {
+  const context = await browser.newContext({
+    ignoreHTTPSErrors: false,
+    userAgent: "DarCloud-QA-Smoke/1.0",
+  });
+  const page = await context.newPage();
+  const pageErrors = [];
+  const consoleErrors = [];
+  const failedRequests = [];
+  const badFirstPartyResponses = [];
+
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("requestfailed", (request) => {
+    const requestUrl = new URL(request.url());
+    if (isDarCloudHost(requestUrl.hostname)) {
+      failedRequests.push(`${request.method()} ${request.url()} — ${request.failure()?.errorText || "failed"}`);
+    }
+  });
+  page.on("response", (response) => {
+    const responseUrl = new URL(response.url());
+    if (isDarCloudHost(responseUrl.hostname) && response.status() >= 500) {
+      badFirstPartyResponses.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  const result = {
+    name: check.name,
+    url: check.url,
+    passed: false,
+    errors: [],
+    warnings: [],
+    status: null,
+    finalUrl: "",
+    title: "",
+    bodyPreview: "",
+    consoleErrors,
+    pageErrors,
+    failedRequests,
+    badFirstPartyResponses,
+  };
+
+  try {
+    const response = await page.goto(check.url, {
+      waitUntil: "domcontentloaded",
+      timeout: NAVIGATION_TIMEOUT_MS,
+    });
+    await page.waitForTimeout(SETTLE_MS);
+
+    result.status = response?.status() ?? null;
+    result.finalUrl = page.url();
+    result.title = await page.title();
+    const bodyText = (await page.locator("body").innerText({ timeout: 5_000 })).replace(/\s+/g, " ").trim();
+    result.bodyPreview = bodyText.slice(0, 300);
+
+    if (!response) result.errors.push("navigation returned no document response");
+    if (result.status === null || result.status >= 400) result.errors.push(`document status was ${result.status}`);
+    if (bodyText.length < 40) result.errors.push(`page body was unexpectedly small (${bodyText.length} characters)`);
+
+    for (const marker of forbiddenBodyMarkers) {
+      if (`${result.title}\n${bodyText}`.includes(marker)) {
+        result.errors.push(`page contains failure marker: ${marker}`);
+      }
+    }
+
+    const searchable = `${result.title}\n${bodyText}`.toLowerCase();
+    if (!check.markers.some((marker) => searchable.includes(marker.toLowerCase()))) {
+      result.errors.push(`none of the expected page markers were present: ${check.markers.join(", ")}`);
+    }
+
+    if (pageErrors.length > 0) result.errors.push(`uncaught browser errors: ${pageErrors.join(" | ")}`);
+    if (failedRequests.length > 0) result.errors.push(`failed first-party requests: ${failedRequests.join(" | ")}`);
+    if (badFirstPartyResponses.length > 0) result.errors.push(`5xx first-party responses: ${badFirstPartyResponses.join(" | ")}`);
+    if (consoleErrors.length > 0) result.warnings.push(`console errors: ${consoleErrors.join(" | ")}`);
+
+    const hrefs = await page.locator("a[href]").evaluateAll((anchors) =>
+      anchors.map((anchor) => anchor.getAttribute("href")).filter(Boolean),
+    );
+    for (const href of hrefs) {
+      try {
+        const resolved = new URL(href, page.url());
+        resolved.hash = "";
+        if (shouldCheckLink(resolved)) discoveredLinks.add(resolved.href);
+      } catch {
+        result.warnings.push(`invalid link: ${href}`);
+      }
+    }
+
+    result.passed = result.errors.length === 0;
+  } catch (error) {
+    result.errors.push(String(error));
+  } finally {
+    await context.close();
+  }
+
+  return result;
+}
+
+async function checkDiscoveredLink(url) {
+  const result = { url, passed: false, status: null, finalUrl: "", error: "" };
+  try {
+    const response = await fetch(url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(NAVIGATION_TIMEOUT_MS),
+      headers: { "user-agent": "DarCloud-QA-Smoke/1.0" },
+    });
+    result.status = response.status;
+    result.finalUrl = response.url;
+    result.passed = response.status < 400;
+    if (!result.passed) result.error = `HTTP ${response.status}`;
+    await response.body?.cancel();
+  } catch (error) {
+    result.error = String(error);
+  }
+  return result;
+}
+
+function escapeTable(value) {
+  return String(value ?? "").replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+function buildMarkdown(report) {
+  const lines = [
+    "# DarCloud live-page smoke report",
+    "",
+    `Generated: ${report.generatedAt}`,
+    "",
+    `Overall: **${report.passed ? "PASS" : "FAIL"}**`,
+    "",
+    `Pages: ${report.summary.passedPages}/${report.summary.totalPages} passed`,
+    `Internal links: ${report.summary.passedLinks}/${report.summary.totalLinks} passed`,
+    "",
+    "## Page results",
+    "",
+    "| Status | Page | HTTP | Final URL | Evidence |",
+    "|---|---|---:|---|---|",
+  ];
+
+  for (const item of report.pages) {
+    const evidence = item.passed
+      ? item.title || item.bodyPreview
+      : [...item.errors, ...item.warnings].join("; ");
+    lines.push(`| ${item.passed ? "PASS" : "FAIL"} | ${escapeTable(item.name)} | ${escapeTable(item.status)} | ${escapeTable(item.finalUrl || item.location || item.url)} | ${escapeTable(evidence).slice(0, 500)} |`);
+  }
+
+  lines.push("", "## Internal-link results", "", "| Status | URL | HTTP | Detail |", "|---|---|---:|---|");
+  for (const item of report.links) {
+    lines.push(`| ${item.passed ? "PASS" : "FAIL"} | ${escapeTable(item.url)} | ${escapeTable(item.status)} | ${escapeTable(item.error || item.finalUrl)} |`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  const browser = await chromium.launch({ headless: true });
+  const discoveredLinks = new Set();
+  const pages = [await checkApexRedirect()];
+
+  try {
+    for (const check of pageChecks) {
+      const result = await checkPage(browser, check, discoveredLinks);
+      pages.push(result);
+      console.log(`${result.passed ? "PASS" : "FAIL"} ${check.url} ${result.status ?? "ERR"} ${result.title || result.errors[0] || ""}`);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const links = [];
+  for (const url of [...discoveredLinks].sort().slice(0, MAX_LINKS)) {
+    const result = await checkDiscoveredLink(url);
+    links.push(result);
+    console.log(`${result.passed ? "PASS" : "FAIL"} link ${url} ${result.status ?? "ERR"}`);
+  }
+
+  const summary = {
+    totalPages: pages.length,
+    passedPages: pages.filter((item) => item.passed).length,
+    totalLinks: links.length,
+    passedLinks: links.filter((item) => item.passed).length,
+  };
+  const report = {
+    generatedAt: new Date().toISOString(),
+    passed: summary.passedPages === summary.totalPages && summary.passedLinks === summary.totalLinks,
+    summary,
+    pages,
+    links,
+  };
+
+  await writeFile(`${OUTPUT_DIR}/report.json`, `${JSON.stringify(report, null, 2)}\n`);
+  await writeFile(`${OUTPUT_DIR}/report.md`, buildMarkdown(report));
+
+  console.log(`\nDarCloud smoke result: ${report.passed ? "PASS" : "FAIL"}`);
+  console.log(`Pages: ${summary.passedPages}/${summary.totalPages}; links: ${summary.passedLinks}/${summary.totalLinks}`);
+  if (!report.passed) process.exitCode = 1;
+}
+
+main().catch(async (error) => {
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  await writeFile(`${OUTPUT_DIR}/fatal.txt`, `${error?.stack || error}\n`);
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/darcloud-post-deploy-check.mjs
+++ b/scripts/darcloud-post-deploy-check.mjs
@@ -1,0 +1,149 @@
+const REQUEST_TIMEOUT_MS = 20_000;
+const RETRY_DELAYS_MS = [0, 2_000, 5_000];
+
+const checks = [
+  ["www home", "https://www.darcloud.host/", ["DarCloud"]],
+  ["AI", "https://ai.darcloud.host/", ["AI"]],
+  ["API gateway", "https://api-gateway.darcloud.host/", ["API"]],
+  ["blockchain", "https://blockchain.darcloud.host/", ["Blockchain", "QuranChain"]],
+  ["checkout", "https://checkout.darcloud.host/", ["Checkout", "Payment", "Plans"]],
+  ["commerce", "https://commerce.darcloud.host/", ["Commerce", "Marketplace"]],
+  ["DeFi", "https://defi.darcloud.host/", ["DeFi", "Finance"]],
+  ["education", "https://edu.darcloud.host/", ["Education", "Learning"]],
+  ["energy", "https://energy.darcloud.host/", ["Energy", "Grid"]],
+  ["health", "https://health.darcloud.host/", ["Health", "Care"]],
+  ["HR", "https://hr.darcloud.host/", ["Human", "HR", "Workforce"]],
+  ["law", "https://law.darcloud.host/", ["Law", "Legal"]],
+  ["media", "https://media.darcloud.host/", ["Media", "Content"]],
+  ["community", "https://community.darcloud.host/", ["Dar Al-Nas", "Community"]],
+  ["Dar Al-Nas alias", "https://darnas.darcloud.host/", ["Dar Al-Nas", "Community"]],
+  ["pay", "https://pay.darcloud.host/", ["DarPay", "Payment"]],
+  ["security", "https://security.darcloud.host/", ["Security", "Protection"]],
+  ["telecom", "https://telecom.darcloud.host/", ["Telecom", "Network"]],
+  ["trade", "https://trade.darcloud.host/", ["Trade", "Commerce"]],
+  ["transport", "https://transport.darcloud.host/", ["Transport", "Mobility"]],
+  ["enterprise", "https://enterprise.darcloud.host/", ["Enterprise", "Business"]],
+  ["HWC", "https://hwc.darcloud.host/", ["Wealth", "HWC"]],
+  ["HWC alias", "https://halalwealthclub.darcloud.host/", ["Wealth", "HWC"]],
+  ["mesh", "https://mesh.darcloud.host/", ["Mesh", "Network"]],
+  ["MeshTalk", "https://meshtalk.darcloud.host/", ["MeshTalk", "Fungi"]],
+  ["FungiOS alias", "https://fungios.darcloud.host/", ["MeshTalk", "Fungi"]],
+  ["real estate", "https://realestate.darcloud.host/", ["Real Estate", "realestate", "Property"]],
+  ["revenue", "https://revenue.darcloud.host/", ["Revenue", "revenue", "DarCloud Empire"]],
+  ["Omar AI", "https://omarai.darcloud.host/", ["Omar AI", "OmarAI", "Assistant"]],
+  ["affiliate", "https://referral.darcloud.host/", ["Affiliate", "Commission"]],
+  ["signup", "https://darcloud.host/signup", ["Sign Up", "Create Account"]],
+  ["login", "https://darcloud.host/login", ["Login", "Sign In"]],
+  ["onboarding", "https://darcloud.host/onboarding", ["Onboarding", "Welcome", "Setup"]],
+  ["dashboard", "https://darcloud.host/dashboard", ["Dashboard"]],
+  ["admin", "https://darcloud.host/admin", ["Admin"]],
+  ["checkout success", "https://darcloud.host/checkout/success", ["Success", "Payment", "Checkout"]],
+  ["checkout cancel", "https://darcloud.host/checkout/cancel", ["Cancel", "Checkout", "Payment"]],
+  ["checkout plan", "https://darcloud.host/checkout/pro", ["Checkout", "Professional", "Pro"]],
+  ["privacy", "https://darcloud.host/privacy", ["Privacy"]],
+  ["privacy alias", "https://darcloud.host/privacy-policy", ["Privacy"]],
+  ["terms", "https://darcloud.host/terms", ["Terms"]],
+  ["MeshTalk home", "https://darcloud.host/meshtalk", ["MeshTalk"]],
+  ["MeshTalk privacy", "https://darcloud.host/meshtalk/privacy", ["Privacy", "MeshTalk"]],
+  ["MeshTalk terms", "https://darcloud.host/meshtalk/terms", ["Terms", "MeshTalk"]],
+  ["MeshTalk child safety", "https://darcloud.host/meshtalk/child-safety", ["Child", "Safety", "MeshTalk"]],
+];
+
+const forbiddenMarkers = [
+  "Loading platform...",
+  "Connection timed out",
+  "Cloudflare Tunnel error",
+  "Application error: a client-side exception has occurred",
+  "Internal Server Error",
+  "Error 1101",
+];
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function fetchWithRetry(url, options = {}) {
+  let lastError;
+  for (const delay of RETRY_DELAYS_MS) {
+    if (delay) await sleep(delay);
+    try {
+      return await fetch(url, {
+        ...options,
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        headers: {
+          "user-agent": "DarCloud-Post-Deploy-Check/1.0",
+          ...(options.headers || {}),
+        },
+      });
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+async function checkApexRedirect() {
+  const response = await fetchWithRetry("https://darcloud.host/", { redirect: "manual" });
+  const location = response.headers.get("location") || "";
+  const target = location ? new URL(location, "https://darcloud.host/").href : "";
+  const passed = [301, 302, 307, 308].includes(response.status) && target === "https://www.darcloud.host/";
+  return {
+    name: "apex redirect",
+    url: "https://darcloud.host/",
+    status: response.status,
+    finalUrl: target || "https://darcloud.host/",
+    passed,
+    detail: passed ? "canonical redirect is correct" : `expected redirect to https://www.darcloud.host/, received ${response.status} ${location || "without Location"}`,
+  };
+}
+
+async function checkPage([name, url, markers]) {
+  try {
+    const response = await fetchWithRetry(url, { redirect: "follow" });
+    const body = await response.text();
+    const normalized = body.toLowerCase();
+    const markerFound = markers.some((marker) => normalized.includes(marker.toLowerCase()));
+    const forbidden = forbiddenMarkers.find((marker) => body.includes(marker));
+    const passed = response.status < 400 && body.length > 20 && markerFound && !forbidden;
+    const details = [];
+    if (response.status >= 400) details.push(`HTTP ${response.status}`);
+    if (body.length <= 20) details.push(`body only ${body.length} characters`);
+    if (!markerFound) details.push(`missing marker: ${markers.join(" | ")}`);
+    if (forbidden) details.push(`contains failure marker: ${forbidden}`);
+    return {
+      name,
+      url,
+      status: response.status,
+      finalUrl: response.url,
+      passed,
+      detail: details.join("; ") || "page identity verified",
+    };
+  } catch (error) {
+    return { name, url, status: null, finalUrl: "", passed: false, detail: String(error) };
+  }
+}
+
+async function main() {
+  const results = [await checkApexRedirect()];
+  for (const check of checks) {
+    const result = await checkPage(check);
+    results.push(result);
+    console.log(`${result.passed ? "PASS" : "FAIL"} ${result.name} ${result.status ?? "ERR"} ${result.finalUrl || result.url} — ${result.detail}`);
+  }
+
+  const passed = results.filter((result) => result.passed).length;
+  const failed = results.length - passed;
+  console.log(`\nDarCloud post-deploy result: ${failed === 0 ? "PASS" : "FAIL"}`);
+  console.log(`Checks: ${passed}/${results.length} passed`);
+
+  if (failed > 0) {
+    console.error("\nFailed checks:");
+    for (const result of results.filter((item) => !item.passed)) {
+      console.error(`- ${result.name}: ${result.status ?? "ERR"} ${result.detail}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/public/payments.ts
+++ b/src/public/payments.ts
@@ -1,0 +1,460 @@
+import type { Context } from "hono";
+import { requireAuth } from "../endpoints/auth";
+import type { PublicAppEnv } from "./types";
+
+const STRIPE_API = "https://api.stripe.com/v1";
+const MAX_JSON_BYTES = 64 * 1024;
+const MAX_WEBHOOK_BYTES = 1024 * 1024;
+const WEBHOOK_TOLERANCE_SECONDS = 300;
+
+const PLANS = {
+  pro: {
+    label: "DarCloud Professional",
+    priceId: "price_1TAR0SAqs2ifkfkqOKa2Rzq3",
+    amount: 4900,
+  },
+  enterprise: {
+    label: "DarCloud Enterprise",
+    priceId: "price_1TAR0TAqs2ifkfkqdtr8kWEf",
+    amount: 49900,
+  },
+  startup: {
+    label: "DarCloud Enterprise",
+    priceId: "price_1TAR0TAqs2ifkfkqdtr8kWEf",
+    amount: 49900,
+  },
+  fungimesh: {
+    label: "FungiMesh Node",
+    priceId: "price_1TAR0TAqs2ifkfkqqrjzoLdm",
+    amount: 1999,
+  },
+  hwc: {
+    label: "HWC Premium",
+    priceId: "price_1TAR0TAqs2ifkfkqKFPTW7hM",
+    amount: 9900,
+  },
+} as const;
+
+type PlanKey = keyof typeof PLANS;
+
+type StripeCheckoutSession = {
+  id?: string;
+  url?: string;
+  customer?: string;
+  customer_details?: { email?: string };
+  payment_status?: string;
+  amount_total?: number;
+  subscription?: string;
+  payment_intent?: string;
+  metadata?: Record<string, string | undefined>;
+};
+
+type StripeSubscription = {
+  id?: string;
+  status?: string;
+  metadata?: Record<string, string | undefined>;
+};
+
+type StripeEvent = {
+  id?: string;
+  type?: string;
+  data?: { object?: StripeCheckoutSession & StripeSubscription };
+};
+
+function isEmail(value: string): boolean {
+  return value.length <= 254 && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function cleanText(value: unknown, maxLength: number): string {
+  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+}
+
+async function readJsonBody(c: Context<PublicAppEnv>): Promise<Record<string, unknown> | null> {
+  const declaredLength = Number(c.req.header("content-length") || "0");
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_JSON_BYTES) return null;
+
+  try {
+    const text = await c.req.text();
+    if (new TextEncoder().encode(text).byteLength > MAX_JSON_BYTES) return null;
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function stripeAuthorization(secret: string): HeadersInit {
+  return {
+    authorization: `Bearer ${secret}`,
+    "content-type": "application/x-www-form-urlencoded",
+  };
+}
+
+export async function createCheckoutSession(c: Context<PublicAppEnv>): Promise<Response> {
+  const body = await readJsonBody(c);
+  if (!body) return c.json({ error: "Invalid or oversized request" }, 400);
+
+  const plan = cleanText(body.plan, 32) as PlanKey;
+  const email = cleanText(body.email, 254).toLowerCase();
+  const name = cleanText(body.name, 120);
+  const discordId = cleanText(body.discord_id, 80);
+  const selected = PLANS[plan];
+
+  if (!selected || !isEmail(email)) {
+    return c.json({ error: "A valid email and supported plan are required" }, 400);
+  }
+
+  const stripeKey = c.env.STRIPE_SECRET_KEY;
+  if (!stripeKey) {
+    return c.json({ error: "Secure checkout is temporarily unavailable" }, 503);
+  }
+
+  const params = new URLSearchParams();
+  params.set("mode", "subscription");
+  params.set("line_items[0][price]", selected.priceId);
+  params.set("line_items[0][quantity]", "1");
+  params.set("customer_email", email);
+  params.set("success_url", "https://darcloud.host/checkout/success?session_id={CHECKOUT_SESSION_ID}");
+  params.set("cancel_url", "https://darcloud.host/checkout/cancel");
+  params.set("metadata[product]", plan);
+  params.set("metadata[account_email]", email);
+  params.set("subscription_data[metadata][product]", plan);
+  params.set("subscription_data[metadata][account_email]", email);
+  if (name) params.set("metadata[account_name]", name);
+  if (discordId) {
+    params.set("metadata[discord_id]", discordId);
+    params.set("subscription_data[metadata][discord_id]", discordId);
+  }
+
+  try {
+    const stripeResponse = await fetch(`${STRIPE_API}/checkout/sessions`, {
+      method: "POST",
+      headers: stripeAuthorization(stripeKey),
+      body: params.toString(),
+    });
+    const session = (await stripeResponse.json()) as StripeCheckoutSession & {
+      error?: { message?: string };
+    };
+
+    if (!stripeResponse.ok || !session.id || !session.url) {
+      return c.json({ error: "Secure checkout could not be created" }, 502);
+    }
+
+    return c.json({
+      success: true,
+      session_id: session.id,
+      checkout_url: session.url,
+      plan: selected.label,
+      amount: selected.amount,
+      currency: "usd",
+      payment_processor: "Stripe",
+    });
+  } catch {
+    return c.json({ error: "Secure checkout could not be created" }, 502);
+  }
+}
+
+export async function createCustomerPortal(c: Context<PublicAppEnv>): Promise<Response> {
+  const authResponse = await requireAuth(c as never);
+  if (authResponse) return authResponse;
+
+  const user = c.get("user");
+  const email = cleanText(user?.email, 254).toLowerCase();
+  if (!isEmail(email)) return c.json({ error: "Authenticated account is invalid" }, 401);
+
+  const customer = await c.env.DB.prepare(
+    "SELECT darpay_customer_id FROM users WHERE email = ?",
+  )
+    .bind(email)
+    .first<{ darpay_customer_id?: string | null }>();
+
+  if (!customer?.darpay_customer_id) {
+    return c.json({ error: "Billing profile not found" }, 404);
+  }
+
+  const stripeKey = c.env.STRIPE_SECRET_KEY;
+  if (!stripeKey) return c.json({ error: "Billing portal is temporarily unavailable" }, 503);
+
+  const params = new URLSearchParams();
+  params.set("customer", customer.darpay_customer_id);
+  params.set("return_url", "https://darcloud.host/dashboard");
+
+  try {
+    const response = await fetch(`${STRIPE_API}/billing_portal/sessions`, {
+      method: "POST",
+      headers: stripeAuthorization(stripeKey),
+      body: params.toString(),
+    });
+    const data = (await response.json()) as { url?: string };
+    if (!response.ok || !data.url) {
+      return c.json({ error: "Billing portal could not be created" }, 502);
+    }
+    return c.json({ success: true, url: data.url });
+  } catch {
+    return c.json({ error: "Billing portal could not be created" }, 502);
+  }
+}
+
+function hexToBytes(value: string): Uint8Array | null {
+  if (!/^[a-f0-9]{64}$/i.test(value)) return null;
+  const bytes = new Uint8Array(value.length / 2);
+  for (let i = 0; i < value.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(value.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+async function verifyStripeSignature(
+  body: string,
+  signatureHeader: string,
+  secret: string,
+): Promise<boolean> {
+  const values = signatureHeader.split(",").map((part) => part.trim());
+  const timestampValue = values.find((part) => part.startsWith("t="))?.slice(2);
+  const signatures = values
+    .filter((part) => part.startsWith("v1="))
+    .map((part) => part.slice(3));
+
+  const timestamp = Number(timestampValue);
+  if (!Number.isInteger(timestamp) || signatures.length === 0) return false;
+  if (Math.abs(Math.floor(Date.now() / 1000) - timestamp) > WEBHOOK_TOLERANCE_SECONDS) {
+    return false;
+  }
+
+  const encoder = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+  const payload = encoder.encode(`${timestamp}.${body}`);
+
+  for (const signature of signatures) {
+    const bytes = hexToBytes(signature);
+    if (bytes && (await crypto.subtle.verify("HMAC", key, bytes, payload))) return true;
+  }
+  return false;
+}
+
+async function ensureWebhookEventTable(db: D1Database): Promise<void> {
+  await db.prepare(
+    `CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+      event_id TEXT PRIMARY KEY,
+      event_type TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'processing',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      processed_at TEXT
+    )`,
+  ).run();
+}
+
+async function claimWebhookEvent(
+  db: D1Database,
+  eventId: string,
+  eventType: string,
+): Promise<boolean> {
+  await ensureWebhookEventTable(db);
+  const result = await db
+    .prepare(
+      "INSERT OR IGNORE INTO stripe_webhook_events (event_id, event_type, status) VALUES (?, ?, 'processing')",
+    )
+    .bind(eventId, eventType)
+    .run();
+  return Number(result.meta.changes || 0) === 1;
+}
+
+async function processCheckoutCompleted(
+  db: D1Database,
+  session: StripeCheckoutSession,
+): Promise<void> {
+  const plan = cleanText(session.metadata?.product, 32) as PlanKey;
+  const selected = PLANS[plan];
+  const amount = Number(session.amount_total || 0);
+  const email = cleanText(
+    session.customer_details?.email || session.metadata?.account_email,
+    254,
+  ).toLowerCase();
+
+  if (
+    !selected ||
+    session.payment_status !== "paid" ||
+    amount !== selected.amount ||
+    !isEmail(email)
+  ) {
+    return;
+  }
+
+  const user = await db
+    .prepare("SELECT id FROM users WHERE email = ?")
+    .bind(email)
+    .first<{ id: number }>();
+  const userId = user?.id || null;
+  const customerId = cleanText(session.customer, 128);
+  const subscriptionId = cleanText(session.subscription, 128);
+  const discordId = cleanText(session.metadata?.discord_id, 80);
+  const paymentId = cleanText(session.payment_intent || session.id, 128);
+  const sessionId = cleanText(session.id, 128);
+  if (!paymentId || !sessionId) throw new Error("Stripe checkout event is missing identifiers");
+
+  const splits = {
+    founder: Math.floor(amount * 0.3),
+    validators: Math.floor(amount * 0.4),
+    hardware: Math.floor(amount * 0.1),
+    ecosystem: Math.floor(amount * 0.18),
+    zakat: Math.floor(amount * 0.02),
+  };
+  const net = Object.values(splits).reduce((sum, value) => sum + value, 0);
+  const period = new Date().toISOString().slice(0, 7);
+
+  const statements = [
+    db
+      .prepare(
+        `INSERT INTO revenue_ledger (
+          payment_id, stripe_session_id, discord_id, product, gross_amount,
+          founder_amount, validators_amount, hardware_amount, ecosystem_amount,
+          zakat_amount, discord_cut, net_amount, source, status, period
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'stripe', 'confirmed', ?)`,
+      )
+      .bind(
+        paymentId,
+        sessionId,
+        discordId,
+        plan,
+        amount,
+        splits.founder,
+        splits.validators,
+        splits.hardware,
+        splits.ecosystem,
+        splits.zakat,
+        amount - net,
+        net,
+        period,
+      ),
+    db
+      .prepare(
+        "UPDATE users SET plan = ?, darpay_customer_id = ?, updated_at = datetime('now') WHERE email = ?",
+      )
+      .bind(plan === "startup" ? "enterprise" : plan, customerId || null, email),
+  ];
+
+  for (const [account, value] of Object.entries(splits)) {
+    statements.push(
+      db
+        .prepare(
+          `UPDATE treasury_accounts
+           SET balance_cents = balance_cents + ?,
+               total_received_cents = total_received_cents + ?,
+               updated_at = datetime('now')
+           WHERE account_type = ?`,
+        )
+        .bind(value, value, account),
+    );
+  }
+
+  if (subscriptionId) {
+    statements.push(
+      db
+        .prepare(
+          `INSERT OR REPLACE INTO active_subscriptions (
+            discord_id, user_id, stripe_subscription_id, stripe_customer_id,
+            product, plan, amount_cents, status, current_period_start
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', datetime('now'))`,
+        )
+        .bind(
+          discordId || email,
+          userId,
+          subscriptionId,
+          customerId,
+          plan,
+          plan === "startup" ? "enterprise" : plan,
+          amount,
+        ),
+    );
+  }
+
+  await db.batch(statements);
+}
+
+async function processSubscriptionLifecycle(
+  db: D1Database,
+  eventType: string,
+  subscription: StripeSubscription,
+): Promise<void> {
+  const id = cleanText(subscription.id, 128);
+  if (!id) return;
+  const status = eventType === "customer.subscription.deleted"
+    ? "canceled"
+    : cleanText(subscription.status, 32) || "unknown";
+  await db
+    .prepare(
+      "UPDATE active_subscriptions SET status = ?, updated_at = datetime('now') WHERE stripe_subscription_id = ?",
+    )
+    .bind(status, id)
+    .run();
+}
+
+export async function handleStripeWebhook(c: Context<PublicAppEnv>): Promise<Response> {
+  const secret = c.env.STRIPE_WEBHOOK_SECRET;
+  if (!secret) return c.json({ error: "Webhook verification is not configured" }, 503);
+
+  const declaredLength = Number(c.req.header("content-length") || "0");
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_WEBHOOK_BYTES) {
+    return c.json({ error: "Webhook payload is too large" }, 413);
+  }
+
+  const body = await c.req.text();
+  if (new TextEncoder().encode(body).byteLength > MAX_WEBHOOK_BYTES) {
+    return c.json({ error: "Webhook payload is too large" }, 413);
+  }
+
+  const signature = c.req.header("stripe-signature") || "";
+  if (!signature || !(await verifyStripeSignature(body, signature, secret))) {
+    return c.json({ error: "Invalid webhook signature" }, 400);
+  }
+
+  let event: StripeEvent;
+  try {
+    event = JSON.parse(body) as StripeEvent;
+  } catch {
+    return c.json({ error: "Invalid webhook payload" }, 400);
+  }
+
+  const eventId = cleanText(event.id, 255);
+  const eventType = cleanText(event.type, 128);
+  if (!eventId || !eventType) return c.json({ error: "Webhook event is incomplete" }, 400);
+
+  const db = c.env.DB;
+  const claimed = await claimWebhookEvent(db, eventId, eventType);
+  if (!claimed) return c.json({ received: true, duplicate: true });
+
+  try {
+    const object = event.data?.object || {};
+    if (eventType === "checkout.session.completed") {
+      await processCheckoutCompleted(db, object);
+    } else if (
+      eventType === "customer.subscription.updated" ||
+      eventType === "customer.subscription.deleted"
+    ) {
+      await processSubscriptionLifecycle(db, eventType, object);
+    }
+
+    await db
+      .prepare(
+        "UPDATE stripe_webhook_events SET status = 'processed', processed_at = datetime('now') WHERE event_id = ?",
+      )
+      .bind(eventId)
+      .run();
+    return c.json({ received: true });
+  } catch {
+    await db
+      .prepare("DELETE FROM stripe_webhook_events WHERE event_id = ?")
+      .bind(eventId)
+      .run()
+      .catch(() => undefined);
+    return c.json({ error: "Webhook processing failed" }, 500);
+  }
+}

--- a/src/public/policies.ts
+++ b/src/public/policies.ts
@@ -1,0 +1,130 @@
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+export function publicPolicyPage(
+  title: string,
+  summary: string,
+  sections: Array<{ heading: string; body: string }>,
+): string {
+  const renderedSections = sections
+    .map(
+      ({ heading, body }) => `
+        <section>
+          <h2>${escapeHtml(heading)}</h2>
+          <p>${escapeHtml(body)}</p>
+        </section>`,
+    )
+    .join("");
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${escapeHtml(title)} | MeshTalk by DarCloud</title>
+  <style>
+    :root{color-scheme:dark;background:#07090f;color:#e6edf3;font-family:Inter,system-ui,sans-serif}
+    *{box-sizing:border-box}body{margin:0;min-height:100vh;background:linear-gradient(180deg,#07111c,#07090f)}
+    header,main,footer{width:min(900px,calc(100% - 2rem));margin:auto}header{padding:2.5rem 0 1.25rem;border-bottom:1px solid #243142}
+    a{color:#55d7ff}h1{font-size:clamp(2rem,6vw,3.5rem);margin:.5rem 0}h2{color:#6ee7b7;margin-bottom:.4rem}
+    .eyebrow{color:#f7c65f;text-transform:uppercase;letter-spacing:.14em;font-size:.8rem}.summary{color:#a8b3c7;font-size:1.1rem;line-height:1.7}
+    section{background:#0d1520;border:1px solid #243142;border-radius:14px;padding:1.25rem;margin:1rem 0}section p{line-height:1.7;color:#c4cedd;margin:.25rem 0}
+    nav{display:flex;gap:1rem;flex-wrap:wrap;margin-top:1.25rem}footer{padding:2rem 0;color:#8b98aa;font-size:.9rem}
+  </style>
+</head>
+<body>
+  <header>
+    <div class="eyebrow">MeshTalk · DarCloud</div>
+    <h1>${escapeHtml(title)}</h1>
+    <p class="summary">${escapeHtml(summary)}</p>
+    <nav>
+      <a href="/messages">Open Messages</a>
+      <a href="/meshtalk/privacy">Privacy</a>
+      <a href="/meshtalk/terms">Terms</a>
+      <a href="/meshtalk/child-safety">Child Safety</a>
+      <a href="https://www.darcloud.host/">DarCloud</a>
+    </nav>
+  </header>
+  <main>${renderedSections}</main>
+  <footer>© 2026 DarCloud. MeshTalk communications and policy information.</footer>
+</body>
+</html>`;
+}
+
+export const MESHTALK_HOME_PAGE = publicPolicyPage(
+  "MeshTalk",
+  "A DarCloud messaging surface for authorized users, with account controls and safety-first operations.",
+  [
+    {
+      heading: "Messages",
+      body: "Sign in with your DarCloud account to start or continue conversations. Messaging APIs require an authenticated session.",
+    },
+    {
+      heading: "Privacy and safety",
+      body: "Review the privacy, terms, and child-safety pages before using MeshTalk. Report abuse through the support channels shown in the application.",
+    },
+  ],
+);
+
+export const MESHTALK_PRIVACY_PAGE = publicPolicyPage(
+  "MeshTalk Privacy Policy",
+  "How MeshTalk handles account and conversation information.",
+  [
+    {
+      heading: "Information used",
+      body: "MeshTalk uses DarCloud account identity and conversation data needed to deliver messaging features. Access is limited to authenticated users and authorized operations.",
+    },
+    {
+      heading: "Retention and requests",
+      body: "Retention is limited to operational and legal needs. Users may submit access, correction, or deletion requests through DarCloud privacy support.",
+    },
+    {
+      heading: "Security",
+      body: "Credentials, session tokens, and private message content must not be placed in public pages, logs, or issue trackers.",
+    },
+  ],
+);
+
+export const MESHTALK_TERMS_PAGE = publicPolicyPage(
+  "MeshTalk Terms of Service",
+  "Rules for lawful, respectful use of MeshTalk.",
+  [
+    {
+      heading: "Authorized use",
+      body: "Users may access only their own account and conversations or information they are explicitly authorized to use.",
+    },
+    {
+      heading: "Prohibited activity",
+      body: "Abuse, harassment, fraud, malware, credential theft, unauthorized access, and unlawful content are prohibited.",
+    },
+    {
+      heading: "Service changes",
+      body: "DarCloud may restrict or suspend access to protect users, comply with law, or preserve platform security and reliability.",
+    },
+  ],
+);
+
+export const MESHTALK_CHILD_SAFETY_PAGE = publicPolicyPage(
+  "MeshTalk Child Safety",
+  "Safety controls and reporting expectations for content involving minors.",
+  [
+    {
+      heading: "Zero tolerance",
+      body: "Child sexual abuse material, exploitation, grooming, trafficking, and sexualization of minors are prohibited and may be reported to relevant authorities.",
+    },
+    {
+      heading: "Reporting",
+      body: "Users should report suspected child-safety violations through the in-product support channel and appropriate emergency or law-enforcement services when immediate danger exists.",
+    },
+    {
+      heading: "Account protection",
+      body: "Guard account credentials, use age-appropriate supervision, and do not share private contact or location information with unknown parties.",
+    },
+  ],
+);

--- a/src/public/types.ts
+++ b/src/public/types.ts
@@ -1,0 +1,12 @@
+export type PublicBindings = Env & {
+  DARCLOUD_ADMIN_EMAILS?: string;
+};
+
+export type PublicVariables = {
+  user: Record<string, unknown>;
+};
+
+export type PublicAppEnv = {
+  Bindings: PublicBindings;
+  Variables: PublicVariables;
+};

--- a/src/publicEntry.ts
+++ b/src/publicEntry.ts
@@ -118,6 +118,33 @@ function rebuiltAuthRequest(request: Request, body: string): Request {
   });
 }
 
+async function reconcileEntitlement(
+  env: PublicBindings,
+  email: string,
+  entitlement: VerifiedEntitlement & { hostingPlan: "pro" | "enterprise" },
+): Promise<void> {
+  const user = await env.DB.prepare(
+    "SELECT id FROM users WHERE lower(email) = ? LIMIT 1",
+  )
+    .bind(email)
+    .first<{ id: number }>();
+  const userId = Number(user?.id || 0);
+  if (!Number.isInteger(userId) || userId <= 0) return;
+
+  await env.DB.batch([
+    env.DB.prepare(
+      `UPDATE users
+       SET plan = ?, darpay_customer_id = ?, updated_at = datetime('now')
+       WHERE id = ? AND lower(email) = ?`,
+    ).bind(entitlement.hostingPlan, entitlement.stripe_customer_id, userId, email),
+    env.DB.prepare(
+      `UPDATE active_subscriptions
+       SET user_id = ?, updated_at = datetime('now')
+       WHERE stripe_subscription_id = ?`,
+    ).bind(userId, entitlement.stripe_subscription_id),
+  ]);
+}
+
 async function handleSignup(
   request: Request,
   env: PublicBindings,
@@ -160,22 +187,7 @@ async function handleSignup(
 
   if (response.ok && entitlement) {
     try {
-      const payload = await response.clone().json<{ user?: { id?: number } }>();
-      const userId = Number(payload.user?.id || 0);
-      if (Number.isInteger(userId) && userId > 0) {
-        await env.DB.batch([
-          env.DB.prepare(
-            `UPDATE users
-             SET plan = ?, darpay_customer_id = ?, updated_at = datetime('now')
-             WHERE id = ? AND lower(email) = ?`,
-          ).bind(entitlement.hostingPlan, entitlement.stripe_customer_id, userId, email),
-          env.DB.prepare(
-            `UPDATE active_subscriptions
-             SET user_id = ?, updated_at = datetime('now')
-             WHERE stripe_subscription_id = ?`,
-          ).bind(userId, entitlement.stripe_subscription_id),
-        ]);
-      }
+      await reconcileEntitlement(env, email, entitlement);
     } catch {
       // Account creation remains successful. The verified subscription can be
       // reconciled again by a later webhook or administrative repair pass.

--- a/src/publicEntry.ts
+++ b/src/publicEntry.ts
@@ -1,0 +1,139 @@
+import publicSite from "./publicSite";
+import type { PublicBindings } from "./public/types";
+
+type PublicWorker = {
+  fetch(request: Request, env: PublicBindings, ctx: ExecutionContext): Response | Promise<Response>;
+};
+
+type VerifiedEntitlement = {
+  plan: string;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string;
+};
+
+const worker = publicSite as unknown as PublicWorker;
+const MAX_SIGNUP_BYTES = 64 * 1024;
+
+function normalizeHostingPlan(plan: string): "pro" | "enterprise" | null {
+  if (plan === "pro") return "pro";
+  if (plan === "enterprise" || plan === "startup") return "enterprise";
+  return null;
+}
+
+function cleanEmail(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase().slice(0, 254) : "";
+}
+
+async function findVerifiedEntitlement(
+  env: PublicBindings,
+  email: string,
+): Promise<(VerifiedEntitlement & { hostingPlan: "pro" | "enterprise" }) | null> {
+  if (!email) return null;
+
+  try {
+    const row = await env.DB.prepare(
+      `SELECT plan, stripe_customer_id, stripe_subscription_id
+       FROM active_subscriptions
+       WHERE lower(discord_id) = ?
+         AND status IN ('active', 'trialing')
+       ORDER BY created_at DESC
+       LIMIT 1`,
+    )
+      .bind(email)
+      .first<VerifiedEntitlement>();
+
+    if (!row?.stripe_subscription_id) return null;
+    const hostingPlan = normalizeHostingPlan(row.plan);
+    return hostingPlan ? { ...row, hostingPlan } : null;
+  } catch {
+    return null;
+  }
+}
+
+function rebuiltRequest(request: Request, body: string): Request {
+  const headers = new Headers(request.headers);
+  headers.delete("content-length");
+  return new Request(request.url, {
+    method: request.method,
+    headers,
+    body,
+    redirect: request.redirect,
+  });
+}
+
+async function handleSignup(
+  request: Request,
+  env: PublicBindings,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const declaredLength = Number(request.headers.get("content-length") || "0");
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_SIGNUP_BYTES) {
+    return worker.fetch(rebuiltRequest(request, "{}"), env, ctx);
+  }
+
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > MAX_SIGNUP_BYTES) {
+    return worker.fetch(rebuiltRequest(request, "{}"), env, ctx);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return worker.fetch(rebuiltRequest(request, text), env, ctx);
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return worker.fetch(rebuiltRequest(request, text), env, ctx);
+  }
+
+  const email = cleanEmail(body.email);
+  const entitlement = await findVerifiedEntitlement(env, email);
+  const response = await worker.fetch(
+    rebuiltRequest(
+      request,
+      JSON.stringify({
+        ...body,
+        plan: entitlement?.hostingPlan || "starter",
+      }),
+    ),
+    env,
+    ctx,
+  );
+
+  if (!response.ok || !entitlement) return response;
+
+  try {
+    const payload = await response.clone().json<{ user?: { id?: number } }>();
+    const userId = Number(payload.user?.id || 0);
+    if (!Number.isInteger(userId) || userId <= 0) return response;
+
+    await env.DB.batch([
+      env.DB.prepare(
+        `UPDATE users
+         SET plan = ?, darpay_customer_id = ?, updated_at = datetime('now')
+         WHERE id = ? AND lower(email) = ?`,
+      ).bind(entitlement.hostingPlan, entitlement.stripe_customer_id, userId, email),
+      env.DB.prepare(
+        `UPDATE active_subscriptions
+         SET user_id = ?, updated_at = datetime('now')
+         WHERE stripe_subscription_id = ?`,
+      ).bind(userId, entitlement.stripe_subscription_id),
+    ]);
+  } catch {
+    // Account creation remains successful. The verified subscription can be
+    // reconciled again by a later webhook or administrative repair pass.
+  }
+
+  return response;
+}
+
+export default {
+  async fetch(request: Request, env: PublicBindings, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === "/api/auth/signup") {
+      return handleSignup(request, env, ctx);
+    }
+    return worker.fetch(request, env, ctx);
+  },
+};

--- a/src/publicEntry.ts
+++ b/src/publicEntry.ts
@@ -1,4 +1,5 @@
 import publicSite from "./publicSite";
+import { auth } from "./endpoints/auth";
 import type { PublicBindings } from "./public/types";
 
 type PublicWorker = {
@@ -12,6 +13,7 @@ type VerifiedEntitlement = {
 };
 
 const worker = publicSite as unknown as PublicWorker;
+const authWorker = auth as unknown as PublicWorker;
 const MAX_SIGNUP_BYTES = 64 * 1024;
 
 function normalizeHostingPlan(plan: string): "pro" | "enterprise" | null {
@@ -22,6 +24,58 @@ function normalizeHostingPlan(plan: string): "pro" | "enterprise" | null {
 
 function cleanEmail(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase().slice(0, 254) : "";
+}
+
+function isAllowedOrigin(origin: string): boolean {
+  return /^https:\/\/([a-z0-9-]+\.)?darcloud\.(host|net)$/i.test(origin);
+}
+
+function appendVary(headers: Headers, value: string): void {
+  const values = (headers.get("vary") || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (!values.some((item) => item.toLowerCase() === value.toLowerCase())) values.push(value);
+  if (values.length > 0) headers.set("Vary", values.join(", "));
+}
+
+function secureSignupResponse(response: Response, request: Request): Response {
+  const headers = new Headers(response.headers);
+  const origin = request.headers.get("origin") || "";
+  for (const name of [
+    "access-control-allow-origin",
+    "access-control-allow-credentials",
+    "access-control-allow-methods",
+    "access-control-allow-headers",
+  ]) {
+    headers.delete(name);
+  }
+  if (origin) appendVary(headers, "Origin");
+  if (isAllowedOrigin(origin)) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Access-Control-Allow-Credentials", "true");
+  }
+  headers.set("Cache-Control", "no-store");
+  headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  headers.set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; base-uri 'none'");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function secureJson(request: Request, data: unknown, status: number): Response {
+  return secureSignupResponse(
+    new Response(JSON.stringify(data), {
+      status,
+      headers: { "content-type": "application/json;charset=UTF-8" },
+    }),
+    request,
+  );
 }
 
 async function findVerifiedEntitlement(
@@ -50,11 +104,14 @@ async function findVerifiedEntitlement(
   }
 }
 
-function rebuiltRequest(request: Request, body: string): Request {
+function rebuiltAuthRequest(request: Request, body: string): Request {
+  const target = new URL(request.url);
+  target.pathname = "/auth/signup";
+  target.search = "";
   const headers = new Headers(request.headers);
   headers.delete("content-length");
-  return new Request(request.url, {
-    method: request.method,
+  return new Request(target.toString(), {
+    method: "POST",
     headers,
     body,
     redirect: request.redirect,
@@ -68,29 +125,29 @@ async function handleSignup(
 ): Promise<Response> {
   const declaredLength = Number(request.headers.get("content-length") || "0");
   if (Number.isFinite(declaredLength) && declaredLength > MAX_SIGNUP_BYTES) {
-    return worker.fetch(rebuiltRequest(request, "{}"), env, ctx);
+    return secureJson(request, { error: "Request body is too large" }, 413);
   }
 
   const text = await request.text();
   if (new TextEncoder().encode(text).byteLength > MAX_SIGNUP_BYTES) {
-    return worker.fetch(rebuiltRequest(request, "{}"), env, ctx);
+    return secureJson(request, { error: "Request body is too large" }, 413);
   }
 
   let body: Record<string, unknown>;
   try {
     const parsed = JSON.parse(text);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return worker.fetch(rebuiltRequest(request, text), env, ctx);
+      return secureJson(request, { error: "Invalid JSON body" }, 400);
     }
     body = parsed as Record<string, unknown>;
   } catch {
-    return worker.fetch(rebuiltRequest(request, text), env, ctx);
+    return secureJson(request, { error: "Invalid JSON body" }, 400);
   }
 
   const email = cleanEmail(body.email);
   const entitlement = await findVerifiedEntitlement(env, email);
-  const response = await worker.fetch(
-    rebuiltRequest(
+  const response = await authWorker.fetch(
+    rebuiltAuthRequest(
       request,
       JSON.stringify({
         ...body,
@@ -101,31 +158,31 @@ async function handleSignup(
     ctx,
   );
 
-  if (!response.ok || !entitlement) return response;
-
-  try {
-    const payload = await response.clone().json<{ user?: { id?: number } }>();
-    const userId = Number(payload.user?.id || 0);
-    if (!Number.isInteger(userId) || userId <= 0) return response;
-
-    await env.DB.batch([
-      env.DB.prepare(
-        `UPDATE users
-         SET plan = ?, darpay_customer_id = ?, updated_at = datetime('now')
-         WHERE id = ? AND lower(email) = ?`,
-      ).bind(entitlement.hostingPlan, entitlement.stripe_customer_id, userId, email),
-      env.DB.prepare(
-        `UPDATE active_subscriptions
-         SET user_id = ?, updated_at = datetime('now')
-         WHERE stripe_subscription_id = ?`,
-      ).bind(userId, entitlement.stripe_subscription_id),
-    ]);
-  } catch {
-    // Account creation remains successful. The verified subscription can be
-    // reconciled again by a later webhook or administrative repair pass.
+  if (response.ok && entitlement) {
+    try {
+      const payload = await response.clone().json<{ user?: { id?: number } }>();
+      const userId = Number(payload.user?.id || 0);
+      if (Number.isInteger(userId) && userId > 0) {
+        await env.DB.batch([
+          env.DB.prepare(
+            `UPDATE users
+             SET plan = ?, darpay_customer_id = ?, updated_at = datetime('now')
+             WHERE id = ? AND lower(email) = ?`,
+          ).bind(entitlement.hostingPlan, entitlement.stripe_customer_id, userId, email),
+          env.DB.prepare(
+            `UPDATE active_subscriptions
+             SET user_id = ?, updated_at = datetime('now')
+             WHERE stripe_subscription_id = ?`,
+          ).bind(userId, entitlement.stripe_subscription_id),
+        ]);
+      }
+    } catch {
+      // Account creation remains successful. The verified subscription can be
+      // reconciled again by a later webhook or administrative repair pass.
+    }
   }
 
-  return response;
+  return secureSignupResponse(response, request);
 }
 
 export default {

--- a/src/publicGateway.ts
+++ b/src/publicGateway.ts
@@ -1,0 +1,73 @@
+import publicEntry from "./publicEntry";
+import { handleSubdomain } from "./subdomainRouter";
+import type { PublicBindings } from "./public/types";
+
+type PublicWorker = {
+  fetch(request: Request, env: PublicBindings, ctx: ExecutionContext): Response | Promise<Response>;
+};
+
+const worker = publicEntry as unknown as PublicWorker;
+
+function isAllowedOrigin(origin: string): boolean {
+  return /^https:\/\/([a-z0-9-]+\.)?darcloud\.(host|net)$/i.test(origin);
+}
+
+function isAllowedReadOnlySubdomainApi(request: Request): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") return false;
+  const url = new URL(request.url);
+  const aiHost = /^(ai)\.darcloud\.(host|net)$/i.test(url.hostname);
+  const meshHost = /^(mesh)\.darcloud\.(host|net)$/i.test(url.hostname);
+
+  if (aiHost) {
+    return (
+      url.pathname === "/api/fleet" ||
+      url.pathname === "/api/assistants" ||
+      /^\/api\/agent\/[a-z0-9_-]{1,64}$/i.test(url.pathname)
+    );
+  }
+
+  if (meshHost) {
+    return url.pathname === "/api/status" || url.pathname === "/api/nodes";
+  }
+
+  return false;
+}
+
+function secureReadOnlyApiResponse(response: Response, request: Request): Response {
+  const headers = new Headers(response.headers);
+  const origin = request.headers.get("origin") || "";
+  for (const name of [
+    "access-control-allow-origin",
+    "access-control-allow-credentials",
+    "access-control-allow-methods",
+    "access-control-allow-headers",
+  ]) {
+    headers.delete(name);
+  }
+  if (origin) headers.set("Vary", "Origin");
+  if (isAllowedOrigin(origin)) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Access-Control-Allow-Credentials", "true");
+  }
+  headers.set("Cache-Control", "no-store");
+  headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  headers.set("Content-Security-Policy", "default-src 'none'; frame-ancestors 'none'; base-uri 'none'");
+  return new Response(request.method === "HEAD" ? null : response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+export default {
+  async fetch(request: Request, env: PublicBindings, ctx: ExecutionContext): Promise<Response> {
+    if (isAllowedReadOnlySubdomainApi(request)) {
+      const response = await handleSubdomain(request);
+      if (response) return secureReadOnlyApiResponse(response, request);
+    }
+    return worker.fetch(request, env, ctx);
+  },
+};

--- a/src/publicSite.ts
+++ b/src/publicSite.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import type { Context, Next } from "hono";
+import type { Context } from "hono";
 import {
   SIGNUP_PAGE,
   LOGIN_PAGE,
@@ -56,13 +56,11 @@ function appendVary(headers: Headers, value: string): void {
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
-  if (!values.some((item) => item.toLowerCase() === value.toLowerCase())) {
-    values.push(value);
-  }
+  if (!values.some((item) => item.toLowerCase() === value.toLowerCase())) values.push(value);
   if (values.length > 0) headers.set("Vary", values.join(", "));
 }
 
-function applyPublicHeaders(response: Response, origin: string, apiPath: boolean): Response {
+function withPublicHeaders(response: Response, origin: string, noStore: boolean): Response {
   const headers = new Headers(response.headers);
   for (const name of [
     "access-control-allow-origin",
@@ -86,9 +84,9 @@ function applyPublicHeaders(response: Response, origin: string, apiPath: boolean
   headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(self)");
   headers.set(
     "Content-Security-Policy",
-    "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://checkout.stripe.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.darcloud.host https://*.darcloud.net https://api.stripe.com; upgrade-insecure-requests",
+    "default-src 'self' https: data:; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://checkout.stripe.com; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https://*.darcloud.host https://*.darcloud.net https://api.stripe.com; upgrade-insecure-requests",
   );
-  if (apiPath) headers.set("Cache-Control", "no-store");
+  if (noStore) headers.set("Cache-Control", "no-store");
 
   return new Response(response.body, {
     status: response.status,
@@ -118,7 +116,11 @@ app.use("*", async (c, next) => {
   }
 
   await next();
-  c.res = applyPublicHeaders(c.res, origin, path.startsWith("/api/") || path.startsWith("/messaging/"));
+  c.res = withPublicHeaders(
+    c.res,
+    origin,
+    path.startsWith("/api/") || path.startsWith("/messaging/"),
+  );
 });
 
 app.use("*", async (c, next) => {
@@ -133,35 +135,35 @@ app.use("*", async (c, next) => {
 
 app.use("*", async (c, next) => {
   const url = new URL(c.req.url);
-  const isSubdomain = isDarCloudSubdomain(url.hostname);
-  const isNetApex = url.hostname === "darcloud.net";
-
-  if (!isSubdomain && !isNetApex) {
+  const subdomain = isDarCloudSubdomain(url.hostname);
+  const netApex = url.hostname === "darcloud.net";
+  if (!subdomain && !netApex) {
     await next();
     return;
   }
 
-  const isRead = c.req.method === "GET" || c.req.method === "HEAD";
-  const isApiPath = url.pathname.startsWith("/api/") || url.pathname.startsWith("/messaging/");
+  const readOnly = c.req.method === "GET" || c.req.method === "HEAD";
+  const applicationPath = url.pathname.startsWith("/api/") || url.pathname.startsWith("/messaging/");
 
-  if (!isRead) {
-    const safeWrite = SAFE_SUBDOMAIN_WRITE_PATHS.has(url.pathname) || url.pathname.startsWith("/messaging/");
-    if (!safeWrite) return c.json({ error: "This operation is not available on the public site" }, 405);
+  if (!readOnly) {
+    const permitted = SAFE_SUBDOMAIN_WRITE_PATHS.has(url.pathname) || url.pathname.startsWith("/messaging/");
+    if (!permitted) {
+      return c.json({ error: "This operation is not available on the public site" }, 405);
+    }
     await next();
     return;
   }
 
-  if (isApiPath) {
+  if (applicationPath) {
     await next();
     return;
   }
 
   if (url.hostname === "checkout.darcloud.host" || url.hostname === "checkout.darcloud.net") {
-    if (url.pathname === "/" || url.pathname === "/checkout") {
-      return c.html(checkoutPage("pro"));
-    }
+    if (url.pathname === "/" || url.pathname === "/checkout") return c.html(checkoutPage("pro"));
     if (url.pathname.startsWith("/checkout/")) {
-      return c.html(checkoutPage(url.pathname.split("/").filter(Boolean).at(-1) || "pro"));
+      const plan = url.pathname.split("/").filter(Boolean).at(-1) || "pro";
+      return c.html(checkoutPage(plan));
     }
     if (url.pathname === "/success") {
       return c.html(pendingCheckoutPage(url.searchParams.get("session_id") || ""));
@@ -170,27 +172,26 @@ app.use("*", async (c, next) => {
     return c.notFound();
   }
 
-  const response = await handleSubdomain(c.req.raw);
-  if (response) return response;
-  if (isSubdomain || isNetApex) return c.notFound();
-  await next();
+  const routed = await handleSubdomain(c.req.raw);
+  if (routed) return routed;
+  return c.notFound();
 });
 
 function simplePage(title: string, body: string): string {
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title} | DarCloud</title><style>:root{color-scheme:dark;background:#07090f;color:#e6edf3;font-family:Inter,system-ui,sans-serif}body{margin:0;min-height:100vh;background:linear-gradient(180deg,#07111c,#07090f)}main{width:min(900px,calc(100% - 2rem));margin:auto;padding:3rem 0}a{color:#55d7ff}.card{background:#0d1520;border:1px solid #243142;border-radius:16px;padding:1.5rem}h1{font-size:clamp(2rem,6vw,3.5rem)}p{line-height:1.7;color:#c4cedd}code{overflow-wrap:anywhere}</style></head><body><main><div class="card"><h1>${title}</h1>${body}</div></main></body></html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title} | DarCloud</title><style>:root{color-scheme:dark;background:#07090f;color:#e6edf3;font-family:Inter,system-ui,sans-serif}body{margin:0;min-height:100vh;background:linear-gradient(180deg,#07111c,#07090f)}main{width:min(900px,calc(100% - 2rem));margin:auto;padding:3rem 0}a{color:#55d7ff}.card{background:#0d1520;border:1px solid #243142;border-radius:16px;padding:1.5rem}h1{font-size:clamp(2rem,6vw,3.5rem)}p,li{line-height:1.7;color:#c4cedd}code,pre{overflow-wrap:anywhere}</style></head><body><main><div class="card"><h1>${title}</h1>${body}</div></main></body></html>`;
 }
 
 function pendingCheckoutPage(sessionId: string): string {
-  const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 128);
+  const reference = sessionId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 128) || "pending";
   return simplePage(
     "Payment received — verification pending",
-    `<p>Your secure checkout returned successfully. DarCloud activates paid service only after Stripe sends a verified payment webhook.</p><p>Checkout reference: <code>${safeSession || "pending"}</code></p><p><a href="/dashboard">Open your dashboard</a> · <a href="https://www.darcloud.host/">DarCloud home</a></p>`,
+    `<p>Your secure checkout returned successfully. DarCloud activates paid service only after Stripe sends a verified payment webhook.</p><p>Checkout reference: <code>${reference}</code></p><p><a href="/dashboard">Open your dashboard</a> · <a href="https://www.darcloud.host/">DarCloud home</a></p>`,
   );
 }
 
 const PUBLIC_ADMIN_PAGE = simplePage(
   "DarCloud Admin",
-  `<p id="adminStatus">Sign in with an authorized administrator account to view operational statistics.</p><pre id="adminData" style="white-space:pre-wrap;overflow-wrap:anywhere"></pre><p><a href="/dashboard">Back to dashboard</a></p><script>(async()=>{const token=localStorage.getItem('darcloud_token');if(!token){document.getElementById('adminStatus').textContent='Admin sign-in required.';return;}const r=await fetch('/api/admin/stats',{headers:{Authorization:'Bearer '+token}});if(r.status===403){document.getElementById('adminStatus').textContent='Admin access is required for this page.';return;}if(!r.ok){document.getElementById('adminStatus').textContent='Admin data is temporarily unavailable.';return;}const data=await r.json();document.getElementById('adminStatus').textContent='Authorized admin overview';document.getElementById('adminData').textContent=JSON.stringify(data,null,2);})().catch(()=>{document.getElementById('adminStatus').textContent='Admin data is temporarily unavailable.';});</script>`,
+  `<p id="adminStatus">Sign in with an authorized administrator account to view operational statistics.</p><pre id="adminData" style="white-space:pre-wrap"></pre><p><a href="/dashboard">Back to dashboard</a></p><script>(async()=>{const token=localStorage.getItem('darcloud_token');if(!token){document.getElementById('adminStatus').textContent='Admin sign-in required.';return;}const r=await fetch('/api/admin/stats',{headers:{Authorization:'Bearer '+token}});if(r.status===403){document.getElementById('adminStatus').textContent='Admin access is required for this page.';return;}if(!r.ok){document.getElementById('adminStatus').textContent='Admin data is temporarily unavailable.';return;}const data=await r.json();document.getElementById('adminStatus').textContent='Authorized admin overview';document.getElementById('adminData').textContent=JSON.stringify(data,null,2);})().catch(()=>{document.getElementById('adminStatus').textContent='Admin data is temporarily unavailable.';});</script>`,
 );
 
 const DOCS_PAGE = simplePage(
@@ -198,14 +199,10 @@ const DOCS_PAGE = simplePage(
   `<p>This public Worker intentionally exposes only account, contact, privacy, secure checkout, verified Stripe webhook, and authenticated messaging routes.</p><ul><li>GET /health</li><li>POST /api/auth/signup</li><li>POST /api/auth/login</li><li>GET /api/auth/session</li><li>GET /api/auth/me</li><li>POST /api/contact</li><li>POST /api/hwc/apply</li><li>POST /api/privacy-request</li><li>POST /api/checkout/session</li><li>POST /api/stripe/portal</li><li>POST /api/stripe/webhook</li><li>Authenticated /messaging routes</li></ul><p>Infrastructure control-plane routes are not published from this Worker.</p>`,
 );
 
-async function forwardToAuth(
-  c: Context<PublicAppEnv>,
-  internalPath: string,
-  body?: string,
-): Promise<Response> {
+async function forwardToAuth(c: Context<PublicAppEnv>, path: string, body?: string): Promise<Response> {
   const target = new URL(c.req.url);
-  target.pathname = internalPath;
-  target.search = internalPath === "/lookup" ? new URL(c.req.url).search : "";
+  target.pathname = path;
+  target.search = path === "/lookup" ? new URL(c.req.url).search : "";
   const headers = new Headers(c.req.raw.headers);
   headers.delete("content-length");
   const request = new Request(target.toString(), {
@@ -214,6 +211,11 @@ async function forwardToAuth(
     body,
   });
   return auth.fetch(request, c.env, c.executionCtx);
+}
+
+async function proxyAuthBody(c: Context<PublicAppEnv>, path: string): Promise<Response> {
+  const body = ["GET", "HEAD"].includes(c.req.method) ? undefined : await c.req.text();
+  return forwardToAuth(c, path, body);
 }
 
 app.get("/", (c) => c.redirect("https://www.darcloud.host/", 302));
@@ -268,24 +270,13 @@ app.post("/api/auth/signup", async (c) => {
   }
   return forwardToAuth(c, "/auth/signup", JSON.stringify({ ...body, plan: "starter" }));
 });
-
-app.post("/api/auth/login", (c) => forwardToAuth(c, "/auth/login", c.req.raw.body ? undefined : undefined));
-app.post("/api/auth/login", async (c, next) => {
-  await next();
-});
-
-async function proxyBody(c: Context<PublicAppEnv>, path: string): Promise<Response> {
-  const body = ["GET", "HEAD"].includes(c.req.method) ? undefined : await c.req.text();
-  return forwardToAuth(c, path, body);
-}
-
-app.post("/api/auth/login", (c) => proxyBody(c, "/auth/login"));
-app.post("/api/auth/logout", (c) => proxyBody(c, "/auth/logout"));
-app.get("/api/auth/session", (c) => proxyBody(c, "/auth/session"));
-app.get("/api/auth/me", (c) => proxyBody(c, "/auth/me"));
-app.get("/api/lookup", (c) => proxyBody(c, "/lookup"));
-app.post("/api/contact", (c) => proxyBody(c, "/contact"));
-app.post("/api/hwc/apply", (c) => proxyBody(c, "/hwc/apply"));
+app.post("/api/auth/login", (c) => proxyAuthBody(c, "/auth/login"));
+app.post("/api/auth/logout", (c) => proxyAuthBody(c, "/auth/logout"));
+app.get("/api/auth/session", (c) => proxyAuthBody(c, "/auth/session"));
+app.get("/api/auth/me", (c) => proxyAuthBody(c, "/auth/me"));
+app.get("/api/lookup", (c) => proxyAuthBody(c, "/lookup"));
+app.post("/api/contact", (c) => proxyAuthBody(c, "/contact"));
+app.post("/api/hwc/apply", (c) => proxyAuthBody(c, "/hwc/apply"));
 
 app.post("/api/checkout/session", createCheckoutSession);
 app.post("/api/stripe/portal", createCustomerPortal);
@@ -376,7 +367,6 @@ app.get("/api/admin/stats", async (c) => {
 });
 
 app.route("/messaging", messagingRouter);
-
 app.notFound((c) => c.json({ error: "Not found" }, 404));
 app.onError((_error, c) => c.json({ error: "Internal service error" }, 500));
 

--- a/src/publicSite.ts
+++ b/src/publicSite.ts
@@ -1,0 +1,383 @@
+import { Hono } from "hono";
+import type { Context, Next } from "hono";
+import {
+  SIGNUP_PAGE,
+  LOGIN_PAGE,
+  ONBOARDING_PAGE,
+  DASHBOARD_PAGE,
+  PRIVACY_PAGE,
+  TERMS_PAGE,
+  checkoutPage,
+  checkoutResultPage,
+} from "./pages";
+import { handleSubdomain } from "./subdomainRouter";
+import { auth, requireAuth } from "./endpoints/auth";
+import { messagingRouter } from "./endpoints/messaging/router";
+import { MESSAGING_PAGE } from "./components/MessagingSystem";
+import {
+  MESHTALK_CHILD_SAFETY_PAGE,
+  MESHTALK_HOME_PAGE,
+  MESHTALK_PRIVACY_PAGE,
+  MESHTALK_TERMS_PAGE,
+} from "./public/policies";
+import {
+  createCheckoutSession,
+  createCustomerPortal,
+  handleStripeWebhook,
+} from "./public/payments";
+import type { PublicAppEnv } from "./public/types";
+
+const app = new Hono<PublicAppEnv>();
+const MAX_PUBLIC_WRITE_BYTES = 1024 * 1024;
+
+const SAFE_SUBDOMAIN_WRITE_PATHS = new Set([
+  "/api/auth/signup",
+  "/api/auth/login",
+  "/api/auth/logout",
+  "/api/contact",
+  "/api/hwc/apply",
+  "/api/privacy-request",
+  "/api/checkout/session",
+  "/api/stripe/portal",
+  "/api/stripe/webhook",
+  "/api/webhooks/stripe",
+]);
+
+function isAllowedOrigin(origin: string): boolean {
+  return /^https:\/\/([a-z0-9-]+\.)?darcloud\.(host|net)$/i.test(origin);
+}
+
+function isDarCloudSubdomain(hostname: string): boolean {
+  return /^[a-z0-9-]+\.darcloud\.(host|net)$/i.test(hostname);
+}
+
+function appendVary(headers: Headers, value: string): void {
+  const values = (headers.get("vary") || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (!values.some((item) => item.toLowerCase() === value.toLowerCase())) {
+    values.push(value);
+  }
+  if (values.length > 0) headers.set("Vary", values.join(", "));
+}
+
+function applyPublicHeaders(response: Response, origin: string, apiPath: boolean): Response {
+  const headers = new Headers(response.headers);
+  for (const name of [
+    "access-control-allow-origin",
+    "access-control-allow-credentials",
+    "access-control-allow-methods",
+    "access-control-allow-headers",
+  ]) {
+    headers.delete(name);
+  }
+
+  if (origin) appendVary(headers, "Origin");
+  if (isAllowedOrigin(origin)) {
+    headers.set("Access-Control-Allow-Origin", origin);
+    headers.set("Access-Control-Allow-Credentials", "true");
+  }
+
+  headers.set("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=(self)");
+  headers.set(
+    "Content-Security-Policy",
+    "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self' https://checkout.stripe.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.darcloud.host https://*.darcloud.net https://api.stripe.com; upgrade-insecure-requests",
+  );
+  if (apiPath) headers.set("Cache-Control", "no-store");
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+app.use("*", async (c, next) => {
+  const origin = c.req.header("origin") || "";
+  const path = new URL(c.req.url).pathname;
+
+  if (c.req.method === "OPTIONS") {
+    const headers = new Headers({
+      "Access-Control-Allow-Methods": "GET,HEAD,POST,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type,Authorization,Stripe-Signature",
+      "Access-Control-Max-Age": "600",
+      "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+      "X-Content-Type-Options": "nosniff",
+    });
+    appendVary(headers, "Origin");
+    if (isAllowedOrigin(origin)) {
+      headers.set("Access-Control-Allow-Origin", origin);
+      headers.set("Access-Control-Allow-Credentials", "true");
+    }
+    return new Response(null, { status: 204, headers });
+  }
+
+  await next();
+  c.res = applyPublicHeaders(c.res, origin, path.startsWith("/api/") || path.startsWith("/messaging/"));
+});
+
+app.use("*", async (c, next) => {
+  if (!["GET", "HEAD", "OPTIONS"].includes(c.req.method)) {
+    const declaredLength = Number(c.req.header("content-length") || "0");
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_PUBLIC_WRITE_BYTES) {
+      return c.json({ error: "Request body is too large" }, 413);
+    }
+  }
+  await next();
+});
+
+app.use("*", async (c, next) => {
+  const url = new URL(c.req.url);
+  const isSubdomain = isDarCloudSubdomain(url.hostname);
+  const isNetApex = url.hostname === "darcloud.net";
+
+  if (!isSubdomain && !isNetApex) {
+    await next();
+    return;
+  }
+
+  const isRead = c.req.method === "GET" || c.req.method === "HEAD";
+  const isApiPath = url.pathname.startsWith("/api/") || url.pathname.startsWith("/messaging/");
+
+  if (!isRead) {
+    const safeWrite = SAFE_SUBDOMAIN_WRITE_PATHS.has(url.pathname) || url.pathname.startsWith("/messaging/");
+    if (!safeWrite) return c.json({ error: "This operation is not available on the public site" }, 405);
+    await next();
+    return;
+  }
+
+  if (isApiPath) {
+    await next();
+    return;
+  }
+
+  if (url.hostname === "checkout.darcloud.host" || url.hostname === "checkout.darcloud.net") {
+    if (url.pathname === "/" || url.pathname === "/checkout") {
+      return c.html(checkoutPage("pro"));
+    }
+    if (url.pathname.startsWith("/checkout/")) {
+      return c.html(checkoutPage(url.pathname.split("/").filter(Boolean).at(-1) || "pro"));
+    }
+    if (url.pathname === "/success") {
+      return c.html(pendingCheckoutPage(url.searchParams.get("session_id") || ""));
+    }
+    if (url.pathname === "/cancel") return c.html(checkoutResultPage("cancel"));
+    return c.notFound();
+  }
+
+  const response = await handleSubdomain(c.req.raw);
+  if (response) return response;
+  if (isSubdomain || isNetApex) return c.notFound();
+  await next();
+});
+
+function simplePage(title: string, body: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>${title} | DarCloud</title><style>:root{color-scheme:dark;background:#07090f;color:#e6edf3;font-family:Inter,system-ui,sans-serif}body{margin:0;min-height:100vh;background:linear-gradient(180deg,#07111c,#07090f)}main{width:min(900px,calc(100% - 2rem));margin:auto;padding:3rem 0}a{color:#55d7ff}.card{background:#0d1520;border:1px solid #243142;border-radius:16px;padding:1.5rem}h1{font-size:clamp(2rem,6vw,3.5rem)}p{line-height:1.7;color:#c4cedd}code{overflow-wrap:anywhere}</style></head><body><main><div class="card"><h1>${title}</h1>${body}</div></main></body></html>`;
+}
+
+function pendingCheckoutPage(sessionId: string): string {
+  const safeSession = sessionId.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 128);
+  return simplePage(
+    "Payment received — verification pending",
+    `<p>Your secure checkout returned successfully. DarCloud activates paid service only after Stripe sends a verified payment webhook.</p><p>Checkout reference: <code>${safeSession || "pending"}</code></p><p><a href="/dashboard">Open your dashboard</a> · <a href="https://www.darcloud.host/">DarCloud home</a></p>`,
+  );
+}
+
+const PUBLIC_ADMIN_PAGE = simplePage(
+  "DarCloud Admin",
+  `<p id="adminStatus">Sign in with an authorized administrator account to view operational statistics.</p><pre id="adminData" style="white-space:pre-wrap;overflow-wrap:anywhere"></pre><p><a href="/dashboard">Back to dashboard</a></p><script>(async()=>{const token=localStorage.getItem('darcloud_token');if(!token){document.getElementById('adminStatus').textContent='Admin sign-in required.';return;}const r=await fetch('/api/admin/stats',{headers:{Authorization:'Bearer '+token}});if(r.status===403){document.getElementById('adminStatus').textContent='Admin access is required for this page.';return;}if(!r.ok){document.getElementById('adminStatus').textContent='Admin data is temporarily unavailable.';return;}const data=await r.json();document.getElementById('adminStatus').textContent='Authorized admin overview';document.getElementById('adminData').textContent=JSON.stringify(data,null,2);})().catch(()=>{document.getElementById('adminStatus').textContent='Admin data is temporarily unavailable.';});</script>`,
+);
+
+const DOCS_PAGE = simplePage(
+  "DarCloud Public API",
+  `<p>This public Worker intentionally exposes only account, contact, privacy, secure checkout, verified Stripe webhook, and authenticated messaging routes.</p><ul><li>GET /health</li><li>POST /api/auth/signup</li><li>POST /api/auth/login</li><li>GET /api/auth/session</li><li>GET /api/auth/me</li><li>POST /api/contact</li><li>POST /api/hwc/apply</li><li>POST /api/privacy-request</li><li>POST /api/checkout/session</li><li>POST /api/stripe/portal</li><li>POST /api/stripe/webhook</li><li>Authenticated /messaging routes</li></ul><p>Infrastructure control-plane routes are not published from this Worker.</p>`,
+);
+
+async function forwardToAuth(
+  c: Context<PublicAppEnv>,
+  internalPath: string,
+  body?: string,
+): Promise<Response> {
+  const target = new URL(c.req.url);
+  target.pathname = internalPath;
+  target.search = internalPath === "/lookup" ? new URL(c.req.url).search : "";
+  const headers = new Headers(c.req.raw.headers);
+  headers.delete("content-length");
+  const request = new Request(target.toString(), {
+    method: c.req.method,
+    headers,
+    body,
+  });
+  return auth.fetch(request, c.env, c.executionCtx);
+}
+
+app.get("/", (c) => c.redirect("https://www.darcloud.host/", 302));
+app.get("/signup", (c) => c.html(SIGNUP_PAGE));
+app.get("/login", (c) => c.html(LOGIN_PAGE));
+app.get("/onboarding", (c) => c.html(ONBOARDING_PAGE));
+app.get("/dashboard", (c) => c.html(DASHBOARD_PAGE));
+app.get("/admin", (c) => c.html(PUBLIC_ADMIN_PAGE));
+app.get("/checkout", (c) => c.redirect("/checkout/pro", 302));
+app.get("/checkout/success", (c) => c.html(pendingCheckoutPage(c.req.query("session_id") || "")));
+app.get("/checkout/cancel", (c) => c.html(checkoutResultPage("cancel")));
+app.get("/checkout/:plan", (c) => c.html(checkoutPage(c.req.param("plan"))));
+app.get("/privacy", (c) => c.html(PRIVACY_PAGE));
+app.get("/privacy-policy", (c) => c.html(PRIVACY_PAGE));
+app.get("/terms", (c) => c.html(TERMS_PAGE));
+app.get("/messages", (c) => c.html(MESSAGING_PAGE));
+app.get("/meshtalk", (c) => c.html(MESHTALK_HOME_PAGE));
+app.get("/meshtalk/privacy", (c) => c.html(MESHTALK_PRIVACY_PAGE));
+app.get("/meshtalk/terms", (c) => c.html(MESHTALK_TERMS_PAGE));
+app.get("/meshtalk/child-safety", (c) => c.html(MESHTALK_CHILD_SAFETY_PAGE));
+app.get("/docs", (c) => c.html(DOCS_PAGE));
+
+app.get("/health", async (c) => {
+  let tables = 0;
+  let database = "healthy";
+  try {
+    const result = await c.env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM sqlite_master WHERE type = 'table'",
+    ).first<{ count: number }>();
+    tables = Number(result?.count || 0);
+  } catch {
+    database = "unavailable";
+  }
+  return c.json({
+    status: database === "healthy" ? "healthy" : "degraded",
+    service: "darcloud-public",
+    version: "2026.09.02",
+    components: {
+      database: { status: database, tables },
+      ai_agents: 77,
+      control_plane: "not publicly routed",
+    },
+  });
+});
+
+app.post("/api/auth/signup", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json<Record<string, unknown>>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+  return forwardToAuth(c, "/auth/signup", JSON.stringify({ ...body, plan: "starter" }));
+});
+
+app.post("/api/auth/login", (c) => forwardToAuth(c, "/auth/login", c.req.raw.body ? undefined : undefined));
+app.post("/api/auth/login", async (c, next) => {
+  await next();
+});
+
+async function proxyBody(c: Context<PublicAppEnv>, path: string): Promise<Response> {
+  const body = ["GET", "HEAD"].includes(c.req.method) ? undefined : await c.req.text();
+  return forwardToAuth(c, path, body);
+}
+
+app.post("/api/auth/login", (c) => proxyBody(c, "/auth/login"));
+app.post("/api/auth/logout", (c) => proxyBody(c, "/auth/logout"));
+app.get("/api/auth/session", (c) => proxyBody(c, "/auth/session"));
+app.get("/api/auth/me", (c) => proxyBody(c, "/auth/me"));
+app.get("/api/lookup", (c) => proxyBody(c, "/lookup"));
+app.post("/api/contact", (c) => proxyBody(c, "/contact"));
+app.post("/api/hwc/apply", (c) => proxyBody(c, "/hwc/apply"));
+
+app.post("/api/checkout/session", createCheckoutSession);
+app.post("/api/stripe/portal", createCustomerPortal);
+app.post("/api/stripe/webhook", handleStripeWebhook);
+app.post("/api/webhooks/stripe", handleStripeWebhook);
+
+app.post("/api/privacy-request", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json<Record<string, unknown>>();
+  } catch {
+    return c.json({ error: "Invalid JSON body" }, 400);
+  }
+
+  const email = typeof body.email === "string" ? body.email.trim().toLowerCase().slice(0, 254) : "";
+  const type = typeof body.type === "string" ? body.type.trim().slice(0, 40) : "";
+  const details = typeof body.details === "string" ? body.details.trim().slice(0, 2000) : "";
+  const allowedTypes = new Set(["data-access", "data-deletion", "data-export", "opt-out", "other"]);
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || !allowedTypes.has(type)) {
+    return c.json({ error: "A valid email and request type are required" }, 400);
+  }
+
+  const reference = `PR-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
+  try {
+    await c.env.DB.prepare(
+      "INSERT INTO privacy_requests (email, request_type, details, reference, status, created_at) VALUES (?, ?, ?, ?, 'pending', datetime('now'))",
+    )
+      .bind(email, type, details, reference)
+      .run();
+    return c.json({ success: true, reference });
+  } catch {
+    return c.json({ error: "Privacy request service is temporarily unavailable" }, 503);
+  }
+});
+
+app.get("/api/admin/stats", async (c) => {
+  const authResponse = await requireAuth(c as never);
+  if (authResponse) return authResponse;
+  const user = c.get("user");
+  const email = typeof user?.email === "string" ? user.email.toLowerCase() : "";
+  const admins = (c.env.DARCLOUD_ADMIN_EMAILS || "")
+    .split(",")
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  if (!email || admins.length === 0 || !admins.includes(email)) {
+    return c.json({ error: "Admin access required" }, 403);
+  }
+
+  const count = async (table: string): Promise<number> => {
+    try {
+      const result = await c.env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table}`).first<{ count: number }>();
+      return Number(result?.count || 0);
+    } catch {
+      return 0;
+    }
+  };
+
+  const [users, companies, contracts, legalFilings, ipProtections, contacts, hwc] = await Promise.all([
+    count("users"),
+    count("companies"),
+    count("contracts"),
+    count("legal_filings"),
+    count("ip_protections"),
+    count("contact_submissions"),
+    count("hwc_applications"),
+  ]);
+  const recentUsers = await c.env.DB.prepare(
+    "SELECT email, name, plan, created_at FROM users ORDER BY created_at DESC LIMIT 20",
+  ).all();
+  const planBreakdown = await c.env.DB.prepare(
+    "SELECT plan, COUNT(*) AS count FROM users GROUP BY plan ORDER BY plan",
+  ).all();
+
+  return c.json({
+    success: true,
+    stats: {
+      users,
+      companies,
+      contracts,
+      legal_filings: legalFilings,
+      ip_protections: ipProtections,
+      contact_submissions: contacts,
+      hwc_applications: hwc,
+    },
+    recent_users: recentUsers.results,
+    plan_breakdown: planBreakdown.results,
+  });
+});
+
+app.route("/messaging", messagingRouter);
+
+app.notFound((c) => c.json({ error: "Not found" }, 404));
+app.onError((_error, c) => c.json({ error: "Internal service error" }, 500));
+
+export default app;

--- a/src/subdomainRouter.ts
+++ b/src/subdomainRouter.ts
@@ -1,7 +1,6 @@
 // Subdomain → landing page router
 // All *.darcloud.host and *.darcloud.net subdomains are routed through
-// the Cloudflare Tunnel to localhost:8787 (this Worker).
-// This module maps subdomains to their landing page modules.
+// the Cloudflare Worker. This module maps public subdomains to landing pages.
 
 import wwwPage from "../landing-pages/darcloud-www.js";
 import aiPage from "../landing-pages/darcloud-ai-assistant.js";
@@ -29,20 +28,17 @@ import meshtalkPage from "../landing-pages/darcloud-meshtalk.js";
 import netPage from "../landing-pages/darcloud-net.js";
 import omaraiPage from "../landing-pages/darcloud-omarai.js";
 import realEstatePage from "../landing-pages/darcloud-realestate.js";
+import referralPage from "../landing-pages/darcloud-referral.js";
 import revenuePage from "../landing-pages/darcloud-revenue.js";
 
 type LandingPage = { fetch(request: Request): Promise<Response> };
 
-// SSO auth bar script injected into every landing page
-// Checks the darcloud_session cookie via /api/auth/session
-// Replaces "Sign In" nav links with user greeting + dashboard link
 const SSO_AUTH_SCRIPT = `<script>
 (function(){
   var api='https://darcloud.host/api/auth/session';
   fetch(api,{credentials:'include'}).then(function(r){return r.json()}).then(function(d){
     if(!d.authenticated)return;
     var u=d.user;
-    // Find and update "Sign In" links in nav
     document.querySelectorAll('a[href*="/login"],a[href*="Sign In"],a[href*="sign-in"]').forEach(function(a){
       if(a.closest('nav')||a.closest('.nav-links')){
         a.textContent='\\u{1F44B} '+u.name;
@@ -50,7 +46,6 @@ const SSO_AUTH_SCRIPT = `<script>
         a.style.color='#10b981';
       }
     });
-    // Also match text-content based sign-in links
     document.querySelectorAll('nav a, .nav-links a').forEach(function(a){
       if(a.textContent.trim()==='Sign In'||a.textContent.trim()==='Login'){
         a.textContent='\\u{1F44B} '+u.name;
@@ -62,24 +57,19 @@ const SSO_AUTH_SCRIPT = `<script>
 })();
 </script>`;
 
-// Inject SSO script before </body> in landing page HTML
 async function injectSSOScript(response: Response): Promise<Response> {
   const contentType = response.headers.get("content-type") || "";
   if (!contentType.includes("text/html")) return response;
 
   const html = await response.text();
   const injected = html.replace("</body>", SSO_AUTH_SCRIPT + "</body>");
-
-  const newHeaders = new Headers(response.headers);
   return new Response(injected, {
     status: response.status,
-    headers: newHeaders,
+    headers: new Headers(response.headers),
   });
 }
 
-// Map subdomains to their landing page modules
 const SUBDOMAIN_MAP: Record<string, LandingPage> = {
-  // Existing pages
   www: wwwPage,
   ai: aiPage,
   "api-gateway": apiGatewayPage,
@@ -90,9 +80,8 @@ const SUBDOMAIN_MAP: Record<string, LandingPage> = {
   halalwealthclub: hwcPage,
   mesh: meshPage,
   realestate: realEstatePage,
+  referral: referralPage,
   revenue: revenuePage,
-
-  // New sector pages
   pay: payPage,
   meshtalk: meshtalkPage,
   fungios: meshtalkPage,
@@ -113,38 +102,22 @@ const SUBDOMAIN_MAP: Record<string, LandingPage> = {
   omarai: omaraiPage,
 };
 
-// darcloud.net apex gets its own page
 const NET_PAGE: LandingPage = netPage;
 
-/**
- * Handle subdomain routing for *.darcloud.host and darcloud.net.
- * Returns a Response if a matching landing page is found, or null to
- * fall through to the main Hono app routes.
- */
-export async function handleSubdomain(
-  request: Request,
-): Promise<Response | null> {
+export async function handleSubdomain(request: Request): Promise<Response | null> {
   const url = new URL(request.url);
   const hostname = url.hostname;
 
-  // darcloud.net apex → net landing page
   if (hostname === "darcloud.net") {
-    const resp = await NET_PAGE.fetch(request);
-    return injectSSOScript(resp);
+    const response = await NET_PAGE.fetch(request);
+    return injectSSOScript(response);
   }
 
-  // *.darcloud.host or *.darcloud.net subdomains
-  const subMatch = hostname.match(
-    /^([a-z0-9-]+)\.darcloud\.(?:host|net)$/,
-  );
-  if (subMatch) {
-    const subdomain = subMatch[1];
-    const page = SUBDOMAIN_MAP[subdomain];
-    if (page) {
-      const resp = await page.fetch(request);
-      return injectSSOScript(resp);
-    }
-  }
+  const match = hostname.match(/^([a-z0-9-]+)\.darcloud\.(?:host|net)$/);
+  if (!match) return null;
 
-  return null;
+  const page = SUBDOMAIN_MAP[match[1]];
+  if (!page) return null;
+  const response = await page.fetch(request);
+  return injectSSOScript(response);
 }

--- a/tests/integration/public-pages.test.ts
+++ b/tests/integration/public-pages.test.ts
@@ -1,0 +1,95 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+type PageCase = {
+	name: string;
+	url: string;
+	markers: string[];
+	contentType?: string;
+};
+
+const subdomainPages: PageCase[] = [
+	{ name: "www", url: "https://www.darcloud.host/", markers: ["DarCloud"] },
+	{ name: "AI", url: "https://ai.darcloud.host/", markers: ["AI"] },
+	{ name: "API gateway", url: "https://api-gateway.darcloud.host/", markers: ["API"] },
+	{ name: "blockchain", url: "https://blockchain.darcloud.host/", markers: ["Blockchain", "QuranChain"] },
+	{ name: "checkout", url: "https://checkout.darcloud.host/", markers: ["Checkout", "Payment", "Plans"] },
+	{ name: "commerce", url: "https://commerce.darcloud.host/", markers: ["Commerce", "Marketplace"] },
+	{ name: "DeFi", url: "https://defi.darcloud.host/", markers: ["DeFi", "Finance"] },
+	{ name: "education", url: "https://edu.darcloud.host/", markers: ["Education", "Learning"] },
+	{ name: "energy", url: "https://energy.darcloud.host/", markers: ["Energy", "Grid"] },
+	{ name: "health", url: "https://health.darcloud.host/", markers: ["Health", "Care"] },
+	{ name: "HR", url: "https://hr.darcloud.host/", markers: ["Human", "HR", "Workforce"] },
+	{ name: "law", url: "https://law.darcloud.host/", markers: ["Law", "Legal"] },
+	{ name: "media", url: "https://media.darcloud.host/", markers: ["Media", "Content"] },
+	{ name: "community", url: "https://community.darcloud.host/", markers: ["Dar Al-Nas", "Community"] },
+	{ name: "Dar Al-Nas alias", url: "https://darnas.darcloud.host/", markers: ["Dar Al-Nas", "Community"] },
+	{ name: "pay", url: "https://pay.darcloud.host/", markers: ["DarPay", "Payment"] },
+	{ name: "security", url: "https://security.darcloud.host/", markers: ["Security", "Protection"] },
+	{ name: "telecom", url: "https://telecom.darcloud.host/", markers: ["Telecom", "Network"] },
+	{ name: "trade", url: "https://trade.darcloud.host/", markers: ["Trade", "Commerce"] },
+	{ name: "transport", url: "https://transport.darcloud.host/", markers: ["Transport", "Mobility"] },
+	{ name: "enterprise", url: "https://enterprise.darcloud.host/", markers: ["Enterprise", "Business"] },
+	{ name: "HWC", url: "https://hwc.darcloud.host/", markers: ["Wealth", "HWC"] },
+	{ name: "HWC alias", url: "https://halalwealthclub.darcloud.host/", markers: ["Wealth", "HWC"] },
+	{ name: "mesh", url: "https://mesh.darcloud.host/", markers: ["Mesh", "Network"] },
+	{ name: "MeshTalk", url: "https://meshtalk.darcloud.host/", markers: ["MeshTalk", "Fungi"] },
+	{ name: "FungiOS alias", url: "https://fungios.darcloud.host/", markers: ["MeshTalk", "Fungi"] },
+	{ name: "real estate", url: "https://realestate.darcloud.host/", markers: ["Real Estate", "realestate", "Property"] },
+	{ name: "revenue", url: "https://revenue.darcloud.host/", markers: ["Revenue", "revenue"] },
+	{ name: "Omar AI", url: "https://omarai.darcloud.host/", markers: ["Omar AI", "OmarAI", "Assistant"] },
+];
+
+const apexPages: PageCase[] = [
+	{ name: "signup", url: "https://darcloud.host/signup", markers: ["Sign Up", "Create Account"], contentType: "text/html" },
+	{ name: "login", url: "https://darcloud.host/login", markers: ["Login", "Sign In"], contentType: "text/html" },
+	{ name: "onboarding", url: "https://darcloud.host/onboarding", markers: ["Onboarding", "Welcome", "Setup"], contentType: "text/html" },
+	{ name: "dashboard", url: "https://darcloud.host/dashboard", markers: ["Dashboard"], contentType: "text/html" },
+	{ name: "admin", url: "https://darcloud.host/admin", markers: ["Admin"], contentType: "text/html" },
+	{ name: "checkout success", url: "https://darcloud.host/checkout/success", markers: ["Success", "Payment", "Checkout"], contentType: "text/html" },
+	{ name: "checkout cancel", url: "https://darcloud.host/checkout/cancel", markers: ["Cancel", "Checkout", "Payment"], contentType: "text/html" },
+	{ name: "checkout plan", url: "https://darcloud.host/checkout/pro", markers: ["Checkout", "Professional", "Pro"], contentType: "text/html" },
+	{ name: "privacy", url: "https://darcloud.host/privacy", markers: ["Privacy"], contentType: "text/html" },
+	{ name: "privacy alias", url: "https://darcloud.host/privacy-policy", markers: ["Privacy"], contentType: "text/html" },
+	{ name: "terms", url: "https://darcloud.host/terms", markers: ["Terms"], contentType: "text/html" },
+];
+
+function containsExpectedMarker(body: string, markers: string[]): boolean {
+	const normalized = body.toLowerCase();
+	return markers.some((marker) => normalized.includes(marker.toLowerCase()));
+}
+
+async function assertPage(page: PageCase): Promise<void> {
+	const response = await SELF.fetch(page.url, { redirect: "manual" });
+	const body = await response.text();
+
+	expect(response.status, `${page.name} returned ${response.status}: ${body.slice(0, 200)}`).toBe(200);
+	expect(body.length, `${page.name} body is empty`).toBeGreaterThan(20);
+	expect(
+		containsExpectedMarker(body, page.markers),
+		`${page.name} did not contain any expected marker: ${page.markers.join(", ")}; body=${body.slice(0, 300)}`,
+	).toBe(true);
+	if (page.contentType) {
+		expect(response.headers.get("content-type") || "").toContain(page.contentType);
+	}
+}
+
+describe("DarCloud public page contract", () => {
+	it("redirects the apex home page to the canonical www landing page", async () => {
+		const response = await SELF.fetch("https://darcloud.host/", { redirect: "manual" });
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toBe("https://www.darcloud.host/");
+	});
+
+	for (const page of subdomainPages) {
+		it(`renders ${page.name}`, async () => {
+			await assertPage(page);
+		});
+	}
+
+	for (const page of apexPages) {
+		it(`renders ${page.name}`, async () => {
+			await assertPage(page);
+		});
+	}
+});

--- a/tests/integration/public-pages.test.ts
+++ b/tests/integration/public-pages.test.ts
@@ -33,8 +33,6 @@ const subdomainPages: PageCase[] = [
 	{ name: "HWC", url: "https://hwc.darcloud.host/", markers: ["Wealth", "HWC"] },
 	{ name: "HWC alias", url: "https://halalwealthclub.darcloud.host/", markers: ["Wealth", "HWC"] },
 	{ name: "mesh", url: "https://mesh.darcloud.host/", markers: ["Mesh", "Network"] },
-	{ name: "MeshTalk", url: "https://meshtalk.darcloud.host/", markers: ["MeshTalk", "Fungi"] },
-	{ name: "FungiOS alias", url: "https://fungios.darcloud.host/", markers: ["MeshTalk", "Fungi"] },
 	{ name: "real estate", url: "https://realestate.darcloud.host/", markers: ["Real Estate", "realestate", "Property"] },
 	{ name: "revenue", url: "https://revenue.darcloud.host/", markers: ["Revenue", "revenue"] },
 	{ name: "Omar AI", url: "https://omarai.darcloud.host/", markers: ["Omar AI", "OmarAI", "Assistant"] },
@@ -52,6 +50,7 @@ const apexPages: PageCase[] = [
 	{ name: "privacy", url: "https://darcloud.host/privacy", markers: ["Privacy"], contentType: "text/html" },
 	{ name: "privacy alias", url: "https://darcloud.host/privacy-policy", markers: ["Privacy"], contentType: "text/html" },
 	{ name: "terms", url: "https://darcloud.host/terms", markers: ["Terms"], contentType: "text/html" },
+	{ name: "messages", url: "https://darcloud.host/messages", markers: ["Messages", "conversation"], contentType: "text/html" },
 ];
 
 function containsExpectedMarker(body: string, markers: string[]): boolean {
@@ -79,6 +78,15 @@ describe("DarCloud public page contract", () => {
 		const response = await SELF.fetch("https://darcloud.host/", { redirect: "manual" });
 		expect(response.status).toBe(302);
 		expect(response.headers.get("location")).toBe("https://www.darcloud.host/");
+	});
+
+	it.each([
+		["MeshTalk", "https://meshtalk.darcloud.host/"],
+		["FungiOS", "https://fungios.darcloud.host/"],
+	])("redirects the %s alias to the canonical messaging page", async (_name, url) => {
+		const response = await SELF.fetch(url, { redirect: "manual" });
+		expect(response.status).toBe(302);
+		expect(response.headers.get("location")).toBe("https://darcloud.host/messages");
 	});
 
 	for (const page of subdomainPages) {

--- a/tests/integration/revenue-webhook-security.test.ts
+++ b/tests/integration/revenue-webhook-security.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import revenuePage from "../../landing-pages/darcloud-revenue.js";
+
+const makeContext = () => ({
+	waitUntil: vi.fn(),
+});
+
+describe("DarCloud revenue Stripe webhook security", () => {
+	it("fails closed when the webhook secret is not configured", async () => {
+		const request = new Request("https://revenue.darcloud.host/api/webhooks/stripe", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Stripe-Signature": "t=1700000000,v1=deadbeef",
+			},
+			body: JSON.stringify({ id: "evt_test", type: "checkout.session.completed" }),
+		});
+
+		const response = await revenuePage.fetch(request, {}, makeContext());
+		expect(response.status).toBe(400);
+		expect(await response.json()).toEqual({ error: "Invalid webhook signature" });
+	});
+
+	it("rejects a forged signature before forwarding the event", async () => {
+		const timestamp = Math.floor(Date.now() / 1000);
+		const request = new Request("https://revenue.darcloud.host/api/webhooks/stripe", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				"Stripe-Signature": `t=${timestamp},v1=${"0".repeat(64)}`,
+			},
+			body: JSON.stringify({ id: "evt_test", type: "checkout.session.completed" }),
+		});
+		const ctx = makeContext();
+
+		const response = await revenuePage.fetch(
+			request,
+			{ STRIPE_WEBHOOK_SECRET: "test-webhook-secret" },
+			ctx,
+		);
+
+		expect(response.status).toBe(400);
+		expect(ctx.waitUntil).not.toHaveBeenCalled();
+	});
+});

--- a/tests/public/public-site.test.ts
+++ b/tests/public/public-site.test.ts
@@ -1,0 +1,187 @@
+import { SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+
+const publicHosts = [
+  "www",
+  "ai",
+  "api-gateway",
+  "blockchain",
+  "checkout",
+  "commerce",
+  "defi",
+  "edu",
+  "energy",
+  "health",
+  "hr",
+  "law",
+  "media",
+  "community",
+  "darnas",
+  "pay",
+  "security",
+  "telecom",
+  "trade",
+  "transport",
+  "enterprise",
+  "hwc",
+  "halalwealthclub",
+  "mesh",
+  "meshtalk",
+  "fungios",
+  "realestate",
+  "revenue",
+  "omarai",
+];
+
+let uniqueCounter = 0;
+
+async function signup(plan = "starter") {
+  uniqueCounter += 1;
+  const email = `public_${Date.now()}_${uniqueCounter}@darcloud.host`;
+  const response = await SELF.fetch("https://darcloud.host/api/auth/signup", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "cf-connecting-ip": `203.0.113.${(uniqueCounter % 200) + 1}`,
+    },
+    body: JSON.stringify({
+      name: "Public Test User",
+      email,
+      password: "SafeTestPassword123!",
+      plan,
+    }),
+  });
+  return { response, email };
+}
+
+describe("DarCloud public Worker", () => {
+  it("redirects the apex home to the canonical www page", async () => {
+    const response = await SELF.fetch("https://darcloud.host/", { redirect: "manual" });
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://www.darcloud.host/");
+  });
+
+  it.each(publicHosts)("serves the %s public host without a server error", async (host) => {
+    const response = await SELF.fetch(`https://${host}.darcloud.host/`, { redirect: "manual" });
+    expect(response.status).toBeLessThan(400);
+    if (response.status === 302) {
+      expect(response.headers.get("location")).toBe("https://darcloud.host/messages");
+    } else {
+      const body = await response.text();
+      expect(body.length).toBeGreaterThan(20);
+      expect(body).not.toContain("Loading platform...");
+    }
+  });
+
+  it.each([
+    "/signup",
+    "/login",
+    "/onboarding",
+    "/dashboard",
+    "/admin",
+    "/checkout/pro",
+    "/checkout/success",
+    "/checkout/cancel",
+    "/privacy",
+    "/privacy-policy",
+    "/terms",
+    "/messages",
+    "/meshtalk",
+    "/meshtalk/privacy",
+    "/meshtalk/terms",
+    "/meshtalk/child-safety",
+    "/docs",
+    "/health",
+  ])("serves the apex page %s", async (path) => {
+    const response = await SELF.fetch(`https://darcloud.host${path}`, { redirect: "manual" });
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body.length).toBeGreaterThan(20);
+  });
+
+  it("never grants a paid plan directly during signup", async () => {
+    const { response } = await signup("enterprise");
+    expect(response.status).toBe(200);
+    const body = await response.json<{ user: { plan: string }; token: string }>();
+    expect(body.user.plan).toBe("starter");
+    expect(body.token).toBeTruthy();
+  });
+
+  it("fails checkout closed when Stripe is not configured", async () => {
+    const response = await SELF.fetch("https://darcloud.host/api/checkout/session", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        plan: "pro",
+        email: "checkout-test@darcloud.host",
+        name: "Checkout Test",
+      }),
+    });
+    expect(response.status).toBe(503);
+    const body = await response.json<{ success?: boolean; error?: string }>();
+    expect(body.success).not.toBe(true);
+    expect(body.error).toMatch(/unavailable|configured/i);
+  });
+
+  it("requires authentication for Stripe customer portal creation", async () => {
+    const response = await SELF.fetch("https://darcloud.host/api/stripe/portal", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ customer_id: "cus_attacker_controlled" }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("rejects an ordinary user from admin statistics", async () => {
+    const { response: signupResponse } = await signup();
+    const { token } = await signupResponse.json<{ token: string }>();
+    const response = await SELF.fetch("https://darcloud.host/api/admin/stats", {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects unsigned Stripe webhooks", async () => {
+    const response = await SELF.fetch("https://darcloud.host/api/stripe/webhook", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id: "evt_synthetic", type: "checkout.session.completed" }),
+    });
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+
+  it.each([
+    ["POST", "/tasks"],
+    ["POST", "/backups"],
+    ["POST", "/multipass/vms/launch"],
+    ["POST", "/telecom/subscribers"],
+    ["POST", "/api/contracts/bootstrap"],
+    ["POST", "https://ai.darcloud.host/api/chat"],
+  ])("does not expose control-plane mutation %s %s", async (method, path) => {
+    const url = path.startsWith("http") ? path : `https://darcloud.host${path}`;
+    const response = await SELF.fetch(url, {
+      method,
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect([403, 404, 405]).toContain(response.status);
+  });
+
+  it("does not grant CORS to an untrusted browser origin", async () => {
+    const response = await SELF.fetch("https://darcloud.host/login", {
+      headers: { origin: "https://attacker.example" },
+    });
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(response.headers.get("access-control-allow-credentials")).toBeNull();
+  });
+
+  it("echoes only an approved DarCloud origin for credentialed CORS", async () => {
+    const origin = "https://ai.darcloud.host";
+    const response = await SELF.fetch("https://darcloud.host/api/auth/session", {
+      headers: { origin },
+    });
+    expect(response.headers.get("access-control-allow-origin")).toBe(origin);
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(response.headers.get("vary")).toContain("Origin");
+  });
+});

--- a/tests/public/public-site.test.ts
+++ b/tests/public/public-site.test.ts
@@ -1,4 +1,4 @@
-import { SELF } from "cloudflare:test";
+import { env, SELF } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 
 const publicHosts = [
@@ -35,9 +35,9 @@ const publicHosts = [
 
 let uniqueCounter = 0;
 
-async function signup(plan = "starter") {
+async function signup(plan = "starter", requestedEmail?: string) {
   uniqueCounter += 1;
-  const email = `public_${Date.now()}_${uniqueCounter}@darcloud.host`;
+  const email = requestedEmail || `public_${Date.now()}_${uniqueCounter}@darcloud.host`;
   const response = await SELF.fetch("https://darcloud.host/api/auth/signup", {
     method: "POST",
     headers: {
@@ -105,6 +105,32 @@ describe("DarCloud public Worker", () => {
     const body = await response.json<{ user: { plan: string }; token: string }>();
     expect(body.user.plan).toBe("starter");
     expect(body.token).toBeTruthy();
+  });
+
+  it("grants a server-verified subscription when payment preceded account creation", async () => {
+    uniqueCounter += 1;
+    const email = `paid_before_signup_${Date.now()}_${uniqueCounter}@darcloud.host`;
+    await env.DB.prepare(
+      `INSERT INTO active_subscriptions (
+        discord_id, stripe_subscription_id, stripe_customer_id,
+        product, plan, amount_cents, status, current_period_start
+      ) VALUES (?, ?, ?, 'pro', 'pro', 4900, 'active', datetime('now'))`,
+    )
+      .bind(email, `sub_test_${uniqueCounter}`, `cus_test_${uniqueCounter}`)
+      .run();
+
+    const { response } = await signup("enterprise", email);
+    expect(response.status).toBe(200);
+    const body = await response.json<{ user: { plan: string } }>();
+    expect(body.user.plan).toBe("pro");
+
+    const stored = await env.DB.prepare(
+      "SELECT plan, darpay_customer_id FROM users WHERE email = ?",
+    )
+      .bind(email)
+      .first<{ plan: string; darpay_customer_id: string | null }>();
+    expect(stored?.plan).toBe("pro");
+    expect(stored?.darpay_customer_id).toBe(`cus_test_${uniqueCounter}`);
   });
 
   it("fails checkout closed when Stripe is not configured", async () => {

--- a/tests/public/public-site.test.ts
+++ b/tests/public/public-site.test.ts
@@ -31,6 +31,7 @@ const publicHosts = [
   "realestate",
   "revenue",
   "omarai",
+  "referral",
 ];
 
 let uniqueCounter = 0;
@@ -38,6 +39,7 @@ let uniqueCounter = 0;
 async function signup(plan = "starter", requestedEmail?: string) {
   uniqueCounter += 1;
   const email = requestedEmail || `public_${Date.now()}_${uniqueCounter}@darcloud.host`;
+  const password = "SafeTestPassword123!";
   const response = await SELF.fetch("https://darcloud.host/api/auth/signup", {
     method: "POST",
     headers: {
@@ -47,11 +49,22 @@ async function signup(plan = "starter", requestedEmail?: string) {
     body: JSON.stringify({
       name: "Public Test User",
       email,
-      password: "SafeTestPassword123!",
+      password,
       plan,
     }),
   });
-  return { response, email };
+  return { response, email, password };
+}
+
+function userIdFromToken(token: string): number {
+  const part = token.split(".")[1] || "";
+  const padded = part.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(part.length / 4) * 4, "=");
+  const payload = JSON.parse(atob(padded)) as { sub?: number | string };
+  return Number(payload.sub || 0);
+}
+
+function authHeaders(token: string): HeadersInit {
+  return { authorization: `Bearer ${token}`, "content-type": "application/json" };
 }
 
 describe("DarCloud public Worker", () => {
@@ -109,14 +122,17 @@ describe("DarCloud public Worker", () => {
 
   it("grants a server-verified subscription when payment preceded account creation", async () => {
     uniqueCounter += 1;
-    const email = `paid_before_signup_${Date.now()}_${uniqueCounter}@darcloud.host`;
+    const entitlementNumber = uniqueCounter;
+    const email = `paid_before_signup_${Date.now()}_${entitlementNumber}@darcloud.host`;
+    const expectedCustomerId = `cus_test_${entitlementNumber}`;
+    const expectedSubscriptionId = `sub_test_${entitlementNumber}`;
     await env.DB.prepare(
       `INSERT INTO active_subscriptions (
         discord_id, stripe_subscription_id, stripe_customer_id,
         product, plan, amount_cents, status, current_period_start
       ) VALUES (?, ?, ?, 'pro', 'pro', 4900, 'active', datetime('now'))`,
     )
-      .bind(email, `sub_test_${uniqueCounter}`, `cus_test_${uniqueCounter}`)
+      .bind(email, expectedSubscriptionId, expectedCustomerId)
       .run();
 
     const { response } = await signup("enterprise", email);
@@ -130,7 +146,130 @@ describe("DarCloud public Worker", () => {
       .bind(email)
       .first<{ plan: string; darpay_customer_id: string | null }>();
     expect(stored?.plan).toBe("pro");
-    expect(stored?.darpay_customer_id).toBe(`cus_test_${uniqueCounter}`);
+    expect(stored?.darpay_customer_id).toBe(expectedCustomerId);
+
+    const linked = await env.DB.prepare(
+      "SELECT user_id FROM active_subscriptions WHERE stripe_subscription_id = ?",
+    )
+      .bind(expectedSubscriptionId)
+      .first<{ user_id: number | null }>();
+    expect(linked?.user_id).toBeTypeOf("number");
+  });
+
+  it("returns a clear authentication failure for invalid login credentials", async () => {
+    const response = await SELF.fetch("https://darcloud.host/api/auth/login", {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.220" },
+      body: JSON.stringify({ email: "missing@darcloud.host", password: "not-a-real-password" }),
+    });
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type") || "").toContain("application/json");
+  });
+
+  it("accepts the public contact form and persists its synthetic submission", async () => {
+    const email = `contact_${Date.now()}_${++uniqueCounter}@darcloud.host`;
+    const response = await SELF.fetch("https://darcloud.host/api/contact", {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.221" },
+      body: JSON.stringify({ name: "Contact Test", email, subject: "Website test", message: "Synthetic CI submission" }),
+    });
+    expect(response.status).toBeLessThan(300);
+    const stored = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM contact_submissions WHERE email = ?",
+    ).bind(email).first<{ count: number }>();
+    expect(Number(stored?.count || 0)).toBe(1);
+  });
+
+  it("accepts the HWC application form and persists its synthetic submission", async () => {
+    const email = `hwc_${Date.now()}_${++uniqueCounter}@darcloud.host`;
+    const response = await SELF.fetch("https://darcloud.host/api/hwc/apply", {
+      method: "POST",
+      headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.222" },
+      body: JSON.stringify({ name: "HWC Test", email, experience: "Synthetic integration test", interests: "ethical investing" }),
+    });
+    expect(response.status).toBeLessThan(300);
+    const stored = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM hwc_applications WHERE email = ?",
+    ).bind(email).first<{ count: number }>();
+    expect(Number(stored?.count || 0)).toBe(1);
+  });
+
+  it("accepts a bounded privacy request and returns a reference", async () => {
+    const email = `privacy_${Date.now()}_${++uniqueCounter}@darcloud.host`;
+    const response = await SELF.fetch("https://darcloud.host/api/privacy-request", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, type: "data-access", details: "Synthetic integration request" }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json<{ reference?: string }>();
+    expect(body.reference).toMatch(/^PR-/);
+  });
+
+  it("keeps every AI browse-agents link functional", async () => {
+    const page = await SELF.fetch("https://ai.darcloud.host/");
+    const html = await page.text();
+    const links = [...html.matchAll(/href=["'](\/api\/(?:fleet|assistants|agent\/[a-z0-9_-]+))["']/gi)]
+      .map((match) => match[1]);
+    expect(links.length).toBeGreaterThanOrEqual(3);
+    for (const link of new Set(links)) {
+      const response = await SELF.fetch(new URL(link, "https://ai.darcloud.host/").href);
+      expect(response.status, `${link} returned ${response.status}`).toBe(200);
+      expect(response.headers.get("content-type") || "").toContain("application/json");
+    }
+  });
+
+  it("keeps every mesh status link functional", async () => {
+    const page = await SELF.fetch("https://mesh.darcloud.host/");
+    const html = await page.text();
+    const links = [...html.matchAll(/href=["'](\/api\/(?:status|nodes))["']/gi)].map((match) => match[1]);
+    expect(new Set(links)).toEqual(new Set(["/api/status", "/api/nodes"]));
+    for (const link of new Set(links)) {
+      const response = await SELF.fetch(new URL(link, "https://mesh.darcloud.host/").href);
+      expect(response.status, `${link} returned ${response.status}`).toBe(200);
+      expect(response.headers.get("content-type") || "").toContain("application/json");
+    }
+  });
+
+  it("does not ship placeholder blockchain links", async () => {
+    const response = await SELF.fetch("https://blockchain.darcloud.host/");
+    const html = await response.text();
+    expect(html).not.toMatch(/href=["']#["']/i);
+  });
+
+  it("exchanges an authenticated message through the public Worker", async () => {
+    const aliceSignup = await signup();
+    const bobSignup = await signup();
+    const alice = await aliceSignup.response.json<{ token: string }>();
+    const bob = await bobSignup.response.json<{ token: string }>();
+    const bobId = userIdFromToken(bob.token);
+    expect(bobId).toBeGreaterThan(0);
+
+    const create = await SELF.fetch("https://darcloud.host/messaging/conversations", {
+      method: "POST",
+      headers: authHeaders(alice.token),
+      body: JSON.stringify({ type: "direct", participants: [bobId] }),
+    });
+    expect(create.status).toBe(201);
+    const conversation = await create.json<{ conversation_id: number }>();
+
+    const send = await SELF.fetch(
+      `https://darcloud.host/messaging/conversations/${conversation.conversation_id}/messages`,
+      {
+        method: "POST",
+        headers: authHeaders(alice.token),
+        body: JSON.stringify({ content: "Synthetic public Worker message" }),
+      },
+    );
+    expect(send.status).toBe(201);
+
+    const read = await SELF.fetch(
+      `https://darcloud.host/messaging/conversations/${conversation.conversation_id}/messages`,
+      { headers: authHeaders(bob.token) },
+    );
+    expect(read.status).toBe(200);
+    const messages = await read.json<{ messages: Array<{ content: string }> }>();
+    expect(messages.messages.some((message) => message.content === "Synthetic public Worker message")).toBe(true);
   });
 
   it("fails checkout closed when Stripe is not configured", async () => {

--- a/tests/vitest.config.mts
+++ b/tests/vitest.config.mts
@@ -1,32 +1,33 @@
 import path from "node:path";
 import {
-	defineWorkersConfig,
-	readD1Migrations,
+  defineWorkersConfig,
+  readD1Migrations,
 } from "@cloudflare/vitest-pool-workers/config";
 
 const migrationsPath = path.join(__dirname, "..", "migrations");
 const migrations = await readD1Migrations(migrationsPath);
 
 export default defineWorkersConfig({
-	esbuild: {
-		target: "esnext",
-	},
-	test: {
-		setupFiles: ["./tests/apply-migrations.ts"],
-		poolOptions: {
-			workers: {
-				singleWorker: true,
-				wrangler: {
-					configPath: "../wrangler.jsonc",
-				},
-				miniflare: {
-					compatibilityFlags: ["experimental", "nodejs_compat"],
-					bindings: {
-						MIGRATIONS: migrations,
-						JWT_SECRET: "test-only-jwt-secret-do-not-use-in-production",
-					},
-				},
-			},
-		},
-	},
+  esbuild: {
+    target: "esnext",
+  },
+  test: {
+    include: ["tests/integration/**/*.test.ts"],
+    setupFiles: ["./tests/apply-migrations.ts"],
+    poolOptions: {
+      workers: {
+        singleWorker: true,
+        wrangler: {
+          configPath: "../wrangler.jsonc",
+        },
+        miniflare: {
+          compatibilityFlags: ["experimental", "nodejs_compat"],
+          bindings: {
+            MIGRATIONS: migrations,
+            JWT_SECRET: "test-only-jwt-secret-do-not-use-in-production",
+          },
+        },
+      },
+    },
+  },
 });

--- a/tests/vitest.public.config.mts
+++ b/tests/vitest.public.config.mts
@@ -1,0 +1,34 @@
+import path from "node:path";
+import {
+  defineWorkersConfig,
+  readD1Migrations,
+} from "@cloudflare/vitest-pool-workers/config";
+
+const migrationsPath = path.join(__dirname, "..", "migrations");
+const migrations = await readD1Migrations(migrationsPath);
+
+export default defineWorkersConfig({
+  esbuild: {
+    target: "esnext",
+  },
+  test: {
+    include: ["tests/public/**/*.test.ts"],
+    setupFiles: ["./tests/apply-migrations.ts"],
+    poolOptions: {
+      workers: {
+        singleWorker: true,
+        wrangler: {
+          configPath: "../wrangler.public.jsonc",
+        },
+        miniflare: {
+          compatibilityFlags: ["experimental", "nodejs_compat"],
+          bindings: {
+            MIGRATIONS: migrations,
+            JWT_SECRET: "test-only-public-jwt-secret-do-not-use-in-production",
+            DARCLOUD_ADMIN_EMAILS: "admin@darcloud.host",
+          },
+        },
+      },
+    },
+  },
+});

--- a/wrangler.public.jsonc
+++ b/wrangler.public.jsonc
@@ -1,7 +1,7 @@
 {
   "compatibility_date": "2025-10-08",
   "main": "src/publicSite.ts",
-  "name": "darcloud-public",
+  "name": "openapi-template",
   "upload_source_maps": true,
   "observability": {
     "enabled": true

--- a/wrangler.public.jsonc
+++ b/wrangler.public.jsonc
@@ -1,6 +1,6 @@
 {
   "compatibility_date": "2025-10-08",
-  "main": "src/publicSite.ts",
+  "main": "src/publicEntry.ts",
   "name": "openapi-template",
   "upload_source_maps": true,
   "observability": {

--- a/wrangler.public.jsonc
+++ b/wrangler.public.jsonc
@@ -1,0 +1,22 @@
+{
+  "compatibility_date": "2025-10-08",
+  "main": "src/publicSite.ts",
+  "name": "darcloud-public",
+  "upload_source_maps": true,
+  "observability": {
+    "enabled": true
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "openapi-template-db",
+      "database_id": "26b921d0-3226-485d-a105-dc820a9abdbc"
+    }
+  ],
+  "routes": [
+    { "pattern": "darcloud.host/*", "zone_name": "darcloud.host" },
+    { "pattern": "*.darcloud.host/*", "zone_name": "darcloud.host" },
+    { "pattern": "darcloud.net/*", "zone_name": "darcloud.net" },
+    { "pattern": "*.darcloud.net/*", "zone_name": "darcloud.net" }
+  ]
+}


### PR DESCRIPTION
## Purpose
Add a read-only browser smoke audit for the DarCloud public surface before changing production behavior.

## Coverage
- Verifies the apex redirect and `www` landing page.
- Opens every subdomain and alias registered by `src/subdomainRouter.ts`.
- Includes the separately observed affiliate page at `referral.darcloud.host`.
- Opens signup, login, onboarding, dashboard, admin, checkout result/plan, privacy, and terms pages.
- Detects loading-shell failures, missing page identity markers, browser exceptions, first-party request failures, and first-party 5xx responses.
- Extracts and GET-checks safe internal DarCloud links only; no forms, mutations, payments, authentication attempts, or API actions are performed.
- Uploads JSON and Markdown reports on every run, including failures.

## Known live discrepancy before this PR
Current public observation shows both `darcloud.host` and `www.darcloud.host` returning a QuranChain `Loading platform...` shell, while the repository expects the apex to redirect to the DarCloud `www` landing page. This audit is intended to prove the complete failure set before any routing fix.

## Safety
Read-only GET/navigation checks only. No credentials or secrets are required.