### PR TITLE
Security: fail closed on unsafe Open5GS management exposure

### DIFF
--- a/.github/workflows/open5gs-control-plane-security.yml
+++ b/.github/workflows/open5gs-control-plane-security.yml
@@ -1,0 +1,31 @@
+name: Open5GS Control Plane Security
+
+on:
+  pull_request:
+    paths:
+      - "open5gs/**"
+      - ".github/workflows/open5gs-control-plane-security.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  containment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate deploy script syntax
+        run: bash -n open5gs/deploy.sh
+      - name: Require fail-closed management-port gate
+        run: |
+          grep -q 'DARTELECOM_ALLOW_UNSAFE_PORT_PUBLISHING' open5gs/deploy.sh
+          grep -q 'refusing to deploy management/database services with wide host bindings' open5gs/deploy.sh
+      - name: Prevent deployment script from printing static credentials
+        run: |
+          ! grep -q 'WebUI Default Login' open5gs/deploy.sh
+          ! grep -q 'Test subscriber provisioned' open5gs/deploy.sh
+      - name: Confirm known unsafe Compose bindings remain visible to the gate
+        run: |
+          grep -Eq '^[[:space:]]*-[[:space:]]*"27017:27017"[[:space:]]*$' open5gs/docker-compose.yml
+          grep -Eq '^[[:space:]]*-[[:space:]]*"9999:9999"[[:space:]]*$' open5gs/docker-compose.yml
+          grep -Eq '^[[:space:]]*-[[:space:]]*"3000:3000"[[:space:]]*$' open5gs/docker-compose.yml

--- a/open5gs/deploy.sh
+++ b/open5gs/deploy.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # ==========================================================
 # DarTelecom™ / MeshTalk™ — Complete ISP Deployment
-# Deploys Open5GS 5G Core + 4G EPC + ISP Controller
+# Deploys Open5GS 5G SA + 4G EPC + ISP Controller
 # ==========================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -30,6 +30,24 @@ fi
 
 echo "  Docker: $(docker --version)"
 echo "  Compose: $(docker compose version 2>/dev/null || echo 'v2')"
+
+# Security gate: the canonical production deploy path must not publish
+# management/database services on every host interface. Docker Compose
+# entries such as "3000:3000" bind to 0.0.0.0 by default.
+if [ "${DARTELECOM_ALLOW_UNSAFE_PORT_PUBLISHING:-0}" != "1" ]; then
+  unsafe_ports=()
+  grep -Eq '^[[:space:]]*-[[:space:]]*["'"']?27017:27017["'"']?[[:space:]]*$' docker-compose.yml && unsafe_ports+=("MongoDB 27017")
+  grep -Eq '^[[:space:]]*-[[:space:]]*["'"']?9999:9999["'"']?[[:space:]]*$' docker-compose.yml && unsafe_ports+=("Open5GS WebUI 9999")
+  grep -Eq '^[[:space:]]*-[[:space:]]*["'"']?3000:3000["'"']?[[:space:]]*$' docker-compose.yml && unsafe_ports+=("ISP controller 3000")
+
+  if [ "${#unsafe_ports[@]}" -gt 0 ]; then
+    echo "ERROR: refusing to deploy management/database services with wide host bindings."
+    printf '  Unsafe binding: %s\n' "${unsafe_ports[@]}"
+    echo "  Bind these services to loopback/private management interfaces first."
+    echo "  Emergency override only: DARTELECOM_ALLOW_UNSAFE_PORT_PUBLISHING=1"
+    exit 1
+  fi
+fi
 
 # -------- Create TUN device for UPF --------
 echo "[2/7] Configuring network for UPF..."
@@ -99,28 +117,17 @@ echo "    gNodeB (5G Radio)            : running"
 echo "    UE     (Test Device)         : running"
 echo
 echo "  ISP Services:"
-echo "    MongoDB (Subscriber DB)      : localhost:27017"
-echo "    Open5GS WebUI                : http://localhost:9999"
-echo "    ISP Controller API           : http://localhost:3000"
-echo "    ISP Dashboard                : http://localhost:3000/api/dashboard"
+echo "    MongoDB (Subscriber DB)      : private management binding"
+echo "    Open5GS WebUI                : private management binding"
+echo "    ISP Controller API           : private management binding"
+echo "    ISP Dashboard                : private management binding"
 echo
-echo "  WebUI Default Login:"
-echo "    Username: admin"
-echo "    Password: 1423"
+echo "  Administrative credentials:"
+echo "    Provision through the approved runtime secret/identity path."
+echo "    No default administrative password is printed by this script."
 echo
-echo "  Test subscriber provisioned:"
-echo "    IMSI: 999700000000001"
-echo "    Ki:   465B5CE8B199B49FAA5F0A2EE238A6BC"
-echo "    OPc:  E8ED289DEBA952E4283B54E88E6183CA"
-echo
-echo "  Quick test:"
-echo "    curl http://localhost:3000/api/dashboard"
-echo "    curl http://localhost:3000/api/network/status"
-echo "    curl http://localhost:3000/api/plans"
-echo
-echo "  Create a subscriber:"
-echo '    curl -X POST http://localhost:3000/api/subscribers \'
-echo '      -H "Content-Type: application/json" \'
-echo '      -d '"'"'{"name":"Test User","email":"test@darcloud.host","plan":"starter"}'"'"
+echo "  Test subscriber credentials:"
+echo "    Synthetic test SIM credentials are intentionally not printed."
+echo "    Never reuse tracked test credentials for production subscribers."
 echo
 echo "============================================"

--- a/open5gs/deploy.sh
+++ b/open5gs/deploy.sh
@@ -36,9 +36,9 @@ echo "  Compose: $(docker compose version 2>/dev/null || echo 'v2')"
 # entries such as "3000:3000" bind to 0.0.0.0 by default.
 if [ "${DARTELECOM_ALLOW_UNSAFE_PORT_PUBLISHING:-0}" != "1" ]; then
   unsafe_ports=()
-  grep -Eq '^[[:space:]]*-[[:space:]]*["'"']?27017:27017["'"']?[[:space:]]*$' docker-compose.yml && unsafe_ports+=("MongoDB 27017")
-  grep -Eq '^[[:space:]]*-[[:space:]]*["'"']?9999:9999["'"']?[[:space:]]*$' docker-compose.yml && unsafe_ports+=("Open5GS WebUI 9999")
-  grep -Eq '^[[:space:]]*-[[:space:]]*["'"']?3000:3000["'"']?[[:space:]]*$' docker-compose.yml && unsafe_ports+=("ISP controller 3000")
+  grep -Eq "^[[:space:]]*-[[:space:]]*[\"']?27017:27017[\"']?[[:space:]]*$" docker-compose.yml && unsafe_ports+=("MongoDB 27017")
+  grep -Eq "^[[:space:]]*-[[:space:]]*[\"']?9999:9999[\"']?[[:space:]]*$" docker-compose.yml && unsafe_ports+=("Open5GS WebUI 9999")
+  grep -Eq "^[[:space:]]*-[[:space:]]*[\"']?3000:3000[\"']?[[:space:]]*$" docker-compose.yml && unsafe_ports+=("ISP controller 3000")
 
   if [ "${#unsafe_ports[@]}" -gt 0 ]; then
     echo "ERROR: refusing to deploy management/database services with wide host bindings."


### PR DESCRIPTION
Addresses issue #30 with low-risk deployment containment only.

Changes:
- canonical Open5GS deploy script refuses to start while MongoDB, Open5GS WebUI, or ISP controller are published on all host interfaces unless an explicit emergency override is set;
- removes static administrative/test-SIM credential output from the deployment script;
- adds focused CI for shell syntax and containment policy.

This PR intentionally remains draft because the underlying ISP controller still needs fail-closed application authentication, the Compose file still has wide port bindings, and production administrative/test credentials require managed replacement. No live Open5GS, MongoDB, subscriber, SIM, Stripe, or WebUI operation was performed.