### PR TITLE
Security: fail closed DarTelecom control-plane routes

### DIFF
--- a/.github/workflows/telecom-control-plane-security.yml
+++ b/.github/workflows/telecom-control-plane-security.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/endpoints/telecom/**'
       - 'tests/telecom-control-policy.test.js'
+      - 'tests/telecom-control-authz.behavior.mjs'
       - '.github/workflows/telecom-control-plane-security.yml'
   workflow_dispatch:
 
@@ -17,8 +18,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
       - name: Static authorization regression
         run: node tests/telecom-control-policy.test.js
+      - name: Synthetic authorization behavior
+        run: node --experimental-strip-types tests/telecom-control-authz.behavior.mjs
       - name: Install dependencies
         run: npm ci --ignore-scripts
       - name: TypeScript check

--- a/.github/workflows/telecom-control-plane-security.yml
+++ b/.github/workflows/telecom-control-plane-security.yml
@@ -1,0 +1,21 @@
+name: Telecom Control Plane Security
+
+on:
+  pull_request:
+    paths:
+      - 'src/endpoints/telecom/**'
+      - 'tests/telecom-control-policy.test.js'
+      - '.github/workflows/telecom-control-plane-security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  telecom-control-plane-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Static authorization regression
+        run: node tests/telecom-control-policy.test.js

--- a/.github/workflows/telecom-control-plane-security.yml
+++ b/.github/workflows/telecom-control-plane-security.yml
@@ -19,3 +19,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Static authorization regression
         run: node tests/telecom-control-policy.test.js
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: TypeScript check
+        run: npx tsc --noEmit

--- a/src/endpoints/telecom/router.ts
+++ b/src/endpoints/telecom/router.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { authorizeTelecomRequest } from "./security";
 
 const telecomRouter = new Hono<{ Bindings: Env }>();
 
@@ -11,9 +12,29 @@ const ISP_PLANS: Record<string, any> = {
   mesh_node: { name: "MeshTalk Node Operator", price: 0, data_gb: -1, speed_mbps: -1, sms: 0, voice_min: 0 },
 };
 
-// GET /telecom/plans
+// GET /telecom/plans — intentionally public product information
 telecomRouter.get("/plans", (c) => {
   return c.json({ success: true, plans: ISP_PLANS });
+});
+
+// All remaining telecom routes are control-plane/data-plane management surfaces.
+// Fail closed before any D1 access when strong server-managed credentials are absent.
+telecomRouter.use("*", async (c, next) => {
+  const env = c.env as Env & {
+    DARCLOUD_TELECOM_READ_TOKEN?: string;
+    DARCLOUD_TELECOM_MUTATION_TOKEN?: string;
+  };
+  const authorization = await authorizeTelecomRequest(
+    c.req.method,
+    c.req.header("Authorization"),
+    env.DARCLOUD_TELECOM_READ_TOKEN,
+    env.DARCLOUD_TELECOM_MUTATION_TOKEN,
+  );
+  if (!authorization.ok) {
+    return c.json({ success: false, error: authorization.error }, authorization.status);
+  }
+  await next();
+  c.res.headers.set("Cache-Control", "no-store");
 });
 
 // GET /telecom/dashboard — ISP overview
@@ -57,11 +78,11 @@ telecomRouter.get("/dashboard", async (c) => {
     mrr: `$${mrr.toFixed(2)}`,
     arr: `$${(mrr * 12).toFixed(2)}`,
     revenue_split: {
-      founder_30: `$${(mrr * 0.30).toFixed(2)}`,
-      ai_validators_40: `$${(mrr * 0.40).toFixed(2)}`,
-      hardware_hosts_10: `$${(mrr * 0.10).toFixed(2)}`,
-      ecosystem_18: `$${(mrr * 0.18).toFixed(2)}`,
-      zakat_2: `$${(mrr * 0.02).toFixed(2)}`,
+      founder_30: `$${(mrr * 0.30).toFixed(2)} (30%)`,
+      ai_validators_40: `$${(mrr * 0.40).toFixed(2)} (40%)`,
+      hardware_hosts_10: `$${(mrr * 0.10).toFixed(2)} (10%)`,
+      ecosystem_18: `$${(mrr * 0.18).toFixed(2)} (18%)`,
+      zakat_2: `$${(mrr * 0.02).toFixed(2)} (2%)`,
     },
   });
 });

--- a/src/endpoints/telecom/router.ts
+++ b/src/endpoints/telecom/router.ts
@@ -78,11 +78,11 @@ telecomRouter.get("/dashboard", async (c) => {
     mrr: `$${mrr.toFixed(2)}`,
     arr: `$${(mrr * 12).toFixed(2)}`,
     revenue_split: {
-      founder_30: `$${(mrr * 0.30).toFixed(2)} (30%)`,
-      ai_validators_40: `$${(mrr * 0.40).toFixed(2)} (40%)`,
-      hardware_hosts_10: `$${(mrr * 0.10).toFixed(2)} (10%)`,
-      ecosystem_18: `$${(mrr * 0.18).toFixed(2)} (18%)`,
-      zakat_2: `$${(mrr * 0.02).toFixed(2)} (2%)`,
+      founder_30: `$${(mrr * 0.30).toFixed(2)}`,
+      ai_validators_40: `$${(mrr * 0.40).toFixed(2)}`,
+      hardware_hosts_10: `$${(mrr * 0.10).toFixed(2)}`,
+      ecosystem_18: `$${(mrr * 0.18).toFixed(2)}`,
+      zakat_2: `$${(mrr * 0.02).toFixed(2)}`,
     },
   });
 });

--- a/src/endpoints/telecom/security.ts
+++ b/src/endpoints/telecom/security.ts
@@ -1,0 +1,65 @@
+const MIN_CONTROL_TOKEN_LENGTH = 32;
+
+export type TelecomAuthorizationResult =
+  | { ok: true; scope: "read" | "mutation" }
+  | { ok: false; status: 401 | 403 | 503; error: string };
+
+function configuredToken(value: unknown): string | null {
+  return typeof value === "string" && value.length >= MIN_CONTROL_TOKEN_LENGTH
+    ? value
+    : null;
+}
+
+function bearerToken(header: string | undefined): string | null {
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+async function digest(value: string): Promise<Uint8Array> {
+  const bytes = new TextEncoder().encode(value);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+async function secureEqual(left: string, right: string): Promise<boolean> {
+  const [a, b] = await Promise.all([digest(left), digest(right)]);
+  let mismatch = a.length ^ b.length;
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    mismatch |= (a[i] || 0) ^ (b[i] || 0);
+  }
+  return mismatch === 0;
+}
+
+export async function authorizeTelecomRequest(
+  method: string,
+  authorizationHeader: string | undefined,
+  readTokenValue: unknown,
+  mutationTokenValue: unknown,
+): Promise<TelecomAuthorizationResult> {
+  const readToken = configuredToken(readTokenValue);
+  const mutationToken = configuredToken(mutationTokenValue);
+  const isRead = method === "GET" || method === "HEAD";
+  const expected = isRead ? readToken : mutationToken;
+
+  if (!expected) {
+    return {
+      ok: false,
+      status: 503,
+      error: isRead
+        ? "Telecom read authorization is not configured"
+        : "Telecom mutation authorization is not configured",
+    };
+  }
+
+  const supplied = bearerToken(authorizationHeader);
+  if (!supplied) {
+    return { ok: false, status: 401, error: "Authorization required" };
+  }
+
+  if (!(await secureEqual(supplied, expected))) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, scope: isRead ? "read" : "mutation" };
+}

--- a/tests/telecom-control-authz.behavior.mjs
+++ b/tests/telecom-control-authz.behavior.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const { authorizeTelecomRequest } = await import('../src/endpoints/telecom/security.ts');
+const readToken = 'r'.repeat(40);
+const mutationToken = 'm'.repeat(40);
+
+let result = await authorizeTelecomRequest('GET', undefined, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 401);
+
+result = await authorizeTelecomRequest('GET', 'Bearer wrong', readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeTelecomRequest('GET', `Bearer ${readToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'read' });
+
+result = await authorizeTelecomRequest('POST', `Bearer ${readToken}`, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeTelecomRequest('POST', `Bearer ${mutationToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'mutation' });
+
+result = await authorizeTelecomRequest('GET', `Bearer ${readToken}`, 'weak', mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+result = await authorizeTelecomRequest('DELETE', `Bearer ${mutationToken}`, readToken, undefined);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+console.log('telecom authorization behavior: PASS');

--- a/tests/telecom-control-policy.test.js
+++ b/tests/telecom-control-policy.test.js
@@ -1,0 +1,39 @@
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+
+const router = fs.readFileSync('src/endpoints/telecom/router.ts', 'utf8');
+const security = fs.readFileSync('src/endpoints/telecom/security.ts', 'utf8');
+
+const publicPlans = router.indexOf('telecomRouter.get("/plans"');
+const authGate = router.indexOf('telecomRouter.use("*"');
+const firstSensitiveRoute = router.indexOf('telecomRouter.get("/dashboard"');
+
+assert(publicPlans >= 0, 'public plans route must exist');
+assert(authGate > publicPlans, 'authorization gate must be registered after public plans');
+assert(authGate < firstSensitiveRoute, 'authorization gate must precede sensitive telecom routes');
+assert(router.includes('authorizeTelecomRequest('), 'router must invoke the authorization policy');
+assert(router.includes('DARCLOUD_TELECOM_READ_TOKEN'), 'read credential must be server-managed');
+assert(router.includes('DARCLOUD_TELECOM_MUTATION_TOKEN'), 'mutation credential must be server-managed');
+
+for (const route of [
+  'telecomRouter.post("/subscribers"',
+  'telecomRouter.get("/subscribers"',
+  'telecomRouter.patch("/subscribers/:id"',
+  'telecomRouter.delete("/subscribers/:id"',
+  'telecomRouter.get("/sims"',
+  'telecomRouter.get("/esim/:subscriber_id"',
+  'telecomRouter.post("/network/event"',
+  'telecomRouter.post("/mesh/register"',
+  'telecomRouter.post("/mesh/heartbeat"',
+  'telecomRouter.get("/billing/summary"',
+]) {
+  assert(router.indexOf(route) > authGate, `${route} must remain behind the authorization gate`);
+}
+
+assert(security.includes('MIN_CONTROL_TOKEN_LENGTH = 32'), 'weak server credentials must fail closed');
+assert(security.includes('status: 503'), 'missing/weak server config must fail closed');
+assert(security.includes('status: 401'), 'missing bearer credentials must be rejected');
+assert(security.includes('status: 403'), 'wrong bearer credentials must be rejected');
+assert(security.includes('crypto.subtle.digest("SHA-256"'), 'credential comparison must avoid plaintext direct equality');
+
+console.log('telecom control-plane authorization regression: PASS');


### PR DESCRIPTION
## Summary

Containment for #32.

This draft keeps only `/telecom/plans` intentionally public and places a fail-closed authorization boundary before every remaining Cloudflare DarTelecom route can access D1.

Security behavior:
- separate server-managed read and mutation bearer credentials;
- credentials shorter than 32 characters are treated as unconfigured and fail closed with 503;
- missing bearer auth returns 401 and wrong credentials return 403;
- credential comparison uses SHA-256 digests and does not log or return plaintext credentials;
- authorization middleware is registered before dashboard, subscriber, SIM/eSIM, network-event, mesh-management, and billing routes;
- protected responses receive `Cache-Control: no-store`;
- focused source-level regression verifies sensitive routes cannot drift ahead of the authorization gate.

## Safety boundary

No production `/telecom` request, D1 query/mutation, subscriber/SIM/eSIM operation, network event, mesh registration, payment, wallet, or provider call was used to validate this change.

## Human/runtime gates

Before production deployment, provision strong unique `DARCLOUD_TELECOM_READ_TOKEN` and `DARCLOUD_TELECOM_MUTATION_TOKEN` values through the approved Cloudflare/runtime secret manager and update legitimate operator/service clients. Do not put credentials in repository files, shell history, logs, PR comments, or chat.

This is immediate containment, not full tenant authorization. Before closing #32, eSIM/self-service access should be bound to subscriber ownership and mesh ingestion should receive a dedicated service-auth/replay-resistant trust boundary rather than sharing the general mutation credential.

Refs #32