### PR TITLE
Security: contain Multipass fleet control plane

### DIFF
--- a/.github/workflows/multipass-control-plane-security.yml
+++ b/.github/workflows/multipass-control-plane-security.yml
@@ -1,0 +1,32 @@
+name: Multipass Control Plane Security
+
+on:
+  pull_request:
+    paths:
+      - 'src/endpoints/multipass/**'
+      - 'tests/multipass-control-policy.test.js'
+      - 'tests/multipass-control-authz.behavior.mjs'
+      - '.github/workflows/multipass-control-plane-security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  multipass-control-plane-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Static authorization regression
+        run: node tests/multipass-control-policy.test.js
+      - name: Synthetic authorization and command-boundary behavior
+        run: node --experimental-strip-types tests/multipass-control-authz.behavior.mjs
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: TypeScript check
+        run: npx tsc --noEmit

--- a/src/endpoints/multipass/router.ts
+++ b/src/endpoints/multipass/router.ts
@@ -5,8 +5,29 @@ import { MultipassVmLaunch } from "./vmLaunch";
 import { MultipassVmStatus } from "./vmStatus";
 import { MultipassVmDelete } from "./vmDelete";
 import { MultipassFleetHealth } from "./fleetHealth";
+import { authorizeMultipassRequest } from "./security";
 
-export const multipassRouter = fromHono(new Hono());
+export const multipassRouter = fromHono(new Hono<{ Bindings: Env }>());
+
+// Multipass inventory and mutations are infrastructure control-plane operations.
+// Fail closed before any D1 access when strong server-managed credentials are absent.
+multipassRouter.use("*", async (c, next) => {
+  const env = c.env as Env & {
+    DARCLOUD_MULTIPASS_READ_TOKEN?: string;
+    DARCLOUD_MULTIPASS_MUTATION_TOKEN?: string;
+  };
+  const authorization = await authorizeMultipassRequest(
+    c.req.method,
+    c.req.header("Authorization"),
+    env.DARCLOUD_MULTIPASS_READ_TOKEN,
+    env.DARCLOUD_MULTIPASS_MUTATION_TOKEN,
+  );
+  if (!authorization.ok) {
+    return c.json({ success: false, error: authorization.error }, authorization.status);
+  }
+  await next();
+  c.res.headers.set("Cache-Control", "no-store");
+});
 
 multipassRouter.get("/vms", MultipassVmList);
 multipassRouter.post("/vms/launch", MultipassVmLaunch);

--- a/src/endpoints/multipass/security.ts
+++ b/src/endpoints/multipass/security.ts
@@ -1,0 +1,71 @@
+const MIN_CONTROL_TOKEN_LENGTH = 32;
+
+export const VM_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9-]{1,62}[a-z0-9])?$/;
+
+export type MultipassAuthorizationResult =
+  | { ok: true; scope: "read" | "mutation" }
+  | { ok: false; status: 401 | 403 | 503; error: string };
+
+function configuredToken(value: unknown): string | null {
+  return typeof value === "string" && value.length >= MIN_CONTROL_TOKEN_LENGTH
+    ? value
+    : null;
+}
+
+function bearerToken(header: string | undefined): string | null {
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+async function digest(value: string): Promise<Uint8Array> {
+  const bytes = new TextEncoder().encode(value);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+async function secureEqual(left: string, right: string): Promise<boolean> {
+  const [a, b] = await Promise.all([digest(left), digest(right)]);
+  let mismatch = a.length ^ b.length;
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    mismatch |= (a[i] || 0) ^ (b[i] || 0);
+  }
+  return mismatch === 0;
+}
+
+export function isSafeVmName(value: string): boolean {
+  return value.length >= 3 && value.length <= 64 && VM_NAME_PATTERN.test(value);
+}
+
+export async function authorizeMultipassRequest(
+  method: string,
+  authorizationHeader: string | undefined,
+  readTokenValue: unknown,
+  mutationTokenValue: unknown,
+): Promise<MultipassAuthorizationResult> {
+  const readToken = configuredToken(readTokenValue);
+  const mutationToken = configuredToken(mutationTokenValue);
+  const isRead = method === "GET" || method === "HEAD";
+  const expected = isRead ? readToken : mutationToken;
+
+  if (!expected) {
+    return {
+      ok: false,
+      status: 503,
+      error: isRead
+        ? "Multipass read authorization is not configured"
+        : "Multipass mutation authorization is not configured",
+    };
+  }
+
+  const supplied = bearerToken(authorizationHeader);
+  if (!supplied) {
+    return { ok: false, status: 401, error: "Authorization required" };
+  }
+
+  if (!(await secureEqual(supplied, expected))) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, scope: isRead ? "read" : "mutation" };
+}

--- a/src/endpoints/multipass/vmDelete.ts
+++ b/src/endpoints/multipass/vmDelete.ts
@@ -1,6 +1,7 @@
 import { contentJson, OpenAPIRoute } from "chanfana";
 import { AppContext } from "../../types";
 import { z } from "zod";
+import { VM_NAME_PATTERN } from "./security";
 
 export class MultipassVmDelete extends OpenAPIRoute {
 public schema = {
@@ -14,7 +15,7 @@ description:
 operationId: "multipass-vm-delete",
 request: {
 params: z.object({
-id: z.string().describe("VM identifier to permanently remove"),
+id: z.string().min(3).max(64).regex(VM_NAME_PATTERN, "VM identifier must contain only lowercase letters, digits, and internal hyphens").describe("VM identifier to permanently remove"),
 }),
 },
 responses: {
@@ -65,13 +66,25 @@ hint: "Use GET /multipass/vms to list active VMs",
 );
 }
 
+const vmName = String(vm.name);
+if (!VM_NAME_PATTERN.test(vmName) || vmName.length < 3 || vmName.length > 64) {
+return c.json(
+{
+success: false as const,
+error: "Stored VM name is unsafe for host-command generation; manual operator cleanup is required",
+hint: "Do not execute a teardown command derived from this record",
+},
+409,
+);
+}
+
 await db.prepare("DELETE FROM multipass_vms WHERE id = ?").bind(id).run();
 
 return {
 success: true as const,
 deleted: id,
 deleted_at: new Date().toISOString(),
-teardown_command: `multipass delete ${vm.name} --purge`,
+teardown_command: `multipass delete ${vmName} --purge`,
 execution_ms: Date.now() - started,
 };
 }

--- a/src/endpoints/multipass/vmLaunch.ts
+++ b/src/endpoints/multipass/vmLaunch.ts
@@ -1,6 +1,7 @@
 import { contentJson, OpenAPIRoute } from "chanfana";
 import { AppContext } from "../../types";
 import { z } from "zod";
+import { VM_NAME_PATTERN } from "./security";
 
 export class MultipassVmLaunch extends OpenAPIRoute {
 public schema = {
@@ -15,7 +16,7 @@ operationId: "multipass-vm-launch",
 request: {
 body: contentJson(
 z.object({
-name: z.string().min(3).max(64).describe("VM name (e.g. fungimesh-relay1). Must be unique."),
+name: z.string().min(3).max(64).regex(VM_NAME_PATTERN, "VM name must contain only lowercase letters, digits, and internal hyphens").describe("VM name (e.g. fungimesh-relay1). Must be unique."),
 cpus: z.number().int().min(1).max(16).default(2).describe("vCPUs to allocate (1-16)"),
 memory_mb: z.number().int().min(512).max(32768).default(2048).describe("RAM in MB (512-32768)"),
 disk_gb: z.number().int().min(5).max(500).default(10).describe("Disk in GB (5-500)"),

--- a/tests/multipass-control-authz.behavior.mjs
+++ b/tests/multipass-control-authz.behavior.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const { authorizeMultipassRequest, isSafeVmName } = await import('../src/endpoints/multipass/security.ts');
+const readToken = 'r'.repeat(40);
+const mutationToken = 'm'.repeat(40);
+
+let result = await authorizeMultipassRequest('GET', undefined, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 401);
+
+result = await authorizeMultipassRequest('GET', 'Bearer wrong', readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeMultipassRequest('GET', `Bearer ${readToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'read' });
+
+result = await authorizeMultipassRequest('POST', `Bearer ${readToken}`, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeMultipassRequest('DELETE', `Bearer ${mutationToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'mutation' });
+
+result = await authorizeMultipassRequest('GET', `Bearer ${readToken}`, 'weak', mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+result = await authorizeMultipassRequest('POST', `Bearer ${mutationToken}`, readToken, undefined);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+for (const safe of ['vm1', 'fungimesh-relay1', 'node-2026']) {
+  assert.equal(isSafeVmName(safe), true, `${safe} should be accepted`);
+}
+
+for (const unsafe of [
+  'vm;id',
+  'vm$(id)',
+  'vm name',
+  'vm|id',
+  'vm&&id',
+  '-leading',
+  'trailing-',
+  "vm'id",
+]) {
+  assert.equal(isSafeVmName(unsafe), false, `${unsafe} should be rejected`);
+}
+
+console.log('multipass authorization and VM-name behavior: PASS');

--- a/tests/multipass-control-policy.test.js
+++ b/tests/multipass-control-policy.test.js
@@ -1,0 +1,25 @@
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+
+const router = fs.readFileSync('src/endpoints/multipass/router.ts', 'utf8');
+const security = fs.readFileSync('src/endpoints/multipass/security.ts', 'utf8');
+const launch = fs.readFileSync('src/endpoints/multipass/vmLaunch.ts', 'utf8');
+const remove = fs.readFileSync('src/endpoints/multipass/vmDelete.ts', 'utf8');
+
+const authGate = router.indexOf('multipassRouter.use("*"');
+const firstRoute = router.indexOf('multipassRouter.get("/vms"');
+
+assert(authGate >= 0, 'Multipass authorization gate must exist');
+assert(authGate < firstRoute, 'authorization gate must precede every Multipass route');
+assert(router.includes('authorizeMultipassRequest('), 'router must invoke authorization policy');
+assert(router.includes('DARCLOUD_MULTIPASS_READ_TOKEN'), 'read credential must be server-managed');
+assert(router.includes('DARCLOUD_MULTIPASS_MUTATION_TOKEN'), 'mutation credential must be server-managed');
+assert(security.includes('MIN_CONTROL_TOKEN_LENGTH = 32'), 'weak server credentials must fail closed');
+assert(security.includes('status: 503'), 'missing/weak server config must fail closed');
+assert(security.includes('status: 401'), 'missing bearer credentials must be rejected');
+assert(security.includes('status: 403'), 'incorrect/insufficient credentials must be rejected');
+assert(security.includes('crypto.subtle.digest("SHA-256"'), 'credential comparison must avoid plaintext direct equality');
+assert(launch.includes('.regex(VM_NAME_PATTERN'), 'launch must reject unsafe VM names');
+assert(remove.includes('.regex(VM_NAME_PATTERN'), 'delete must reject unsafe VM identifiers before command generation');
+
+console.log('multipass control-plane authorization regression: PASS');


### PR DESCRIPTION
Addresses #34.

This draft adds fail-closed read/mutation authorization before every Multipass route, rejects weak/missing server control credentials, sets authenticated control-plane responses to no-store, and restricts VM identifiers to a conservative shell-safe hostname format before persistence or teardown-command generation.

Focused CI adds provider-free synthetic authorization/name-validation tests, a static route-order regression, dependency install, and TypeScript validation.

Keep this PR draft/unmerged until strong managed `DARCLOUD_MULTIPASS_READ_TOKEN` and `DARCLOUD_MULTIPASS_MUTATION_TOKEN` values are provisioned and legitimate clients are configured. No live D1, VM, host-shell, provider, or network operation was performed during remediation.