### PR TITLE
Security: fail closed ISP subscriber/device control plane

### DIFF
--- a/.github/workflows/isp-control-plane-security.yml
+++ b/.github/workflows/isp-control-plane-security.yml
@@ -1,0 +1,32 @@
+name: ISP Control Plane Security
+
+on:
+  pull_request:
+    paths:
+      - 'src/endpoints/isp/**'
+      - 'tests/isp-control-policy.test.js'
+      - 'tests/isp-control-authz.behavior.mjs'
+      - '.github/workflows/isp-control-plane-security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  isp-control-plane-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Static authorization regression
+        run: node tests/isp-control-policy.test.js
+      - name: Synthetic authorization behavior
+        run: node --experimental-strip-types tests/isp-control-authz.behavior.mjs
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: TypeScript check
+        run: npx tsc --noEmit

--- a/src/endpoints/isp/router.ts
+++ b/src/endpoints/isp/router.ts
@@ -15,14 +15,39 @@ import {
 import { WifiDirectory, WifiHotspotRegister, CoverageMap } from "./wifiDirectory";
 import { SatelliteTracker, SatellitesOverhead, GroundStations, GroundStationRegister } from "./satelliteTracker";
 import { CellTowerRegistry, SignalMap } from "./cellTowers";
+import { authorizeIspRequest } from "./security";
 
-export const ispRouter = fromHono(new Hono());
+export const ispRouter = fromHono(new Hono<{ Bindings: Env }>());
+
+// Deliberately public catalog/map routes. These must remain before the control-plane gate.
+ispRouter.get("/plans", IspPlans);
+ispRouter.get("/wifi-directory", WifiDirectory);
+ispRouter.get("/coverage-map", CoverageMap);
+ispRouter.get("/satellites", SatelliteTracker);
+ispRouter.get("/satellites/overhead", SatellitesOverhead);
+
+// Everything below this point is ISP/telecom infrastructure control-plane data or mutation.
+// Fail closed before handlers and D1 access when strong server-managed credentials are absent.
+ispRouter.use("*", async (c, next) => {
+  const env = c.env as Env & {
+    DARCLOUD_ISP_READ_TOKEN?: string;
+    DARCLOUD_ISP_MUTATION_TOKEN?: string;
+  };
+  const authorization = await authorizeIspRequest(
+    c.req.method,
+    c.req.header("Authorization"),
+    env.DARCLOUD_ISP_READ_TOKEN,
+    env.DARCLOUD_ISP_MUTATION_TOKEN,
+  );
+  if (!authorization.ok) {
+    return c.json({ success: false, error: authorization.error }, authorization.status);
+  }
+  await next();
+  c.res.headers.set("Cache-Control", "no-store");
+});
 
 // Dashboard
 ispRouter.get("/dashboard", IspDashboard);
-
-// Plans
-ispRouter.get("/plans", IspPlans);
 
 // Subscribers
 ispRouter.get("/subscribers", IspSubscribers);
@@ -39,17 +64,11 @@ ispRouter.get("/firmware", IspFirmwareList);
 ispRouter.get("/cellular", IspCellularList);
 ispRouter.post("/cellular/provision", IspCellularProvision);
 
-// Service Areas / Coverage
+// Service Areas / Coverage administration
 ispRouter.get("/coverage", IspServiceAreas);
 
-// WiFi Hotspot Directory (public — shows up on global WiFi maps)
-ispRouter.get("/wifi-directory", WifiDirectory);
+// WiFi hotspot registration mutates the service directory.
 ispRouter.post("/wifi-hotspot/register", WifiHotspotRegister);
-ispRouter.get("/coverage-map", CoverageMap);
-
-// Satellite Tracking (public CelesTrak data — fully legal)
-ispRouter.get("/satellites", SatelliteTracker);
-ispRouter.get("/satellites/overhead", SatellitesOverhead);
 
 // Ground Stations (satellite uplink nodes)
 ispRouter.get("/ground-stations", GroundStations);

--- a/src/endpoints/isp/security.ts
+++ b/src/endpoints/isp/security.ts
@@ -1,0 +1,65 @@
+const MIN_CONTROL_TOKEN_LENGTH = 32;
+
+export type IspAuthorizationResult =
+  | { ok: true; scope: "read" | "mutation" }
+  | { ok: false; status: 401 | 403 | 503; error: string };
+
+function configuredToken(value: unknown): string | null {
+  return typeof value === "string" && value.length >= MIN_CONTROL_TOKEN_LENGTH
+    ? value
+    : null;
+}
+
+function bearerToken(header: string | undefined): string | null {
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+async function digest(value: string): Promise<Uint8Array> {
+  const bytes = new TextEncoder().encode(value);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+async function secureEqual(left: string, right: string): Promise<boolean> {
+  const [a, b] = await Promise.all([digest(left), digest(right)]);
+  let mismatch = a.length ^ b.length;
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    mismatch |= (a[i] || 0) ^ (b[i] || 0);
+  }
+  return mismatch === 0;
+}
+
+export async function authorizeIspRequest(
+  method: string,
+  authorizationHeader: string | undefined,
+  readTokenValue: unknown,
+  mutationTokenValue: unknown,
+): Promise<IspAuthorizationResult> {
+  const readToken = configuredToken(readTokenValue);
+  const mutationToken = configuredToken(mutationTokenValue);
+  const isRead = method === "GET" || method === "HEAD";
+  const expected = isRead ? readToken : mutationToken;
+
+  if (!expected) {
+    return {
+      ok: false,
+      status: 503,
+      error: isRead
+        ? "ISP read authorization is not configured"
+        : "ISP mutation authorization is not configured",
+    };
+  }
+
+  const supplied = bearerToken(authorizationHeader);
+  if (!supplied) {
+    return { ok: false, status: 401, error: "Authorization required" };
+  }
+
+  if (!(await secureEqual(supplied, expected))) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, scope: isRead ? "read" : "mutation" };
+}

--- a/tests/isp-control-authz.behavior.mjs
+++ b/tests/isp-control-authz.behavior.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const { authorizeIspRequest } = await import('../src/endpoints/isp/security.ts');
+const readToken = 'r'.repeat(40);
+const mutationToken = 'm'.repeat(40);
+
+let result = await authorizeIspRequest('GET', undefined, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 401);
+
+result = await authorizeIspRequest('GET', 'Bearer wrong', readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeIspRequest('GET', `Bearer ${readToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'read' });
+
+result = await authorizeIspRequest('POST', `Bearer ${readToken}`, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeIspRequest('POST', `Bearer ${mutationToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'mutation' });
+
+result = await authorizeIspRequest('GET', `Bearer ${readToken}`, 'weak', mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+result = await authorizeIspRequest('POST', `Bearer ${mutationToken}`, readToken, undefined);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+console.log('ISP authorization behavior: PASS');

--- a/tests/isp-control-policy.test.js
+++ b/tests/isp-control-policy.test.js
@@ -1,0 +1,50 @@
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+
+const router = fs.readFileSync('src/endpoints/isp/router.ts', 'utf8');
+const security = fs.readFileSync('src/endpoints/isp/security.ts', 'utf8');
+
+const authGate = router.indexOf('ispRouter.use("*"');
+assert(authGate >= 0, 'ISP authorization gate must exist');
+
+for (const publicRoute of [
+  'ispRouter.get("/plans"',
+  'ispRouter.get("/wifi-directory"',
+  'ispRouter.get("/coverage-map"',
+  'ispRouter.get("/satellites"',
+  'ispRouter.get("/satellites/overhead"',
+]) {
+  const index = router.indexOf(publicRoute);
+  assert(index >= 0 && index < authGate, `${publicRoute} must remain intentionally public before the gate`);
+}
+
+for (const sensitiveRoute of [
+  'ispRouter.get("/dashboard"',
+  'ispRouter.get("/subscribers"',
+  'ispRouter.post("/subscribers/provision"',
+  'ispRouter.get("/devices"',
+  'ispRouter.post("/devices/register"',
+  'ispRouter.get("/firmware"',
+  'ispRouter.get("/cellular"',
+  'ispRouter.post("/cellular/provision"',
+  'ispRouter.get("/coverage"',
+  'ispRouter.post("/wifi-hotspot/register"',
+  'ispRouter.get("/ground-stations"',
+  'ispRouter.post("/ground-stations/register"',
+  'ispRouter.get("/towers"',
+  'ispRouter.get("/signal-map"',
+]) {
+  const index = router.indexOf(sensitiveRoute);
+  assert(index > authGate, `${sensitiveRoute} must be registered behind the authorization gate`);
+}
+
+assert(router.includes('authorizeIspRequest('), 'router must invoke ISP authorization policy');
+assert(router.includes('DARCLOUD_ISP_READ_TOKEN'), 'read credential must be server-managed');
+assert(router.includes('DARCLOUD_ISP_MUTATION_TOKEN'), 'mutation credential must be server-managed');
+assert(security.includes('MIN_CONTROL_TOKEN_LENGTH = 32'), 'weak server credentials must fail closed');
+assert(security.includes('status: 503'), 'missing/weak server config must fail closed');
+assert(security.includes('status: 401'), 'missing bearer credentials must be rejected');
+assert(security.includes('status: 403'), 'incorrect/insufficient credentials must be rejected');
+assert(security.includes('crypto.subtle.digest("SHA-256"'), 'credential comparison must avoid plaintext direct equality');
+
+console.log('ISP control-plane authorization regression: PASS');


### PR DESCRIPTION
Closes #36 after production credentials and negative retest are completed.

## What changes
- Keeps only deliberately public ISP catalog/map routes before the authorization boundary.
- Requires server-managed bearer authorization before sensitive ISP/telecom reads or mutations.
- Separates read and mutation credentials (`DARCLOUD_ISP_READ_TOKEN` / `DARCLOUD_ISP_MUTATION_TOKEN`).
- Fails closed when strong server configuration is missing or weak.
- Uses digest-based comparison and never logs credentials.
- Adds static route-order and synthetic authorization regression tests plus a focused GitHub Actions workflow.

## Safety / deployment gate
This PR is intentionally draft. Production must provision strong managed read/mutation credentials and configure legitimate ISP clients before deployment. Deploying without those values intentionally returns 503 on sensitive control-plane routes.

## Retest target
Anonymous sensitive reads → 401; incorrect credentials → 403; read credential on mutation → 403; correct scoped credential → allowed; missing/weak server configuration → 503; public plans/map/satellite catalog routes remain public.