### PR TITLE
Security: block deploy until contracts control plane is authenticated

### DIFF
--- a/.github/workflows/contracts-control-security.yml
+++ b/.github/workflows/contracts-control-security.yml
@@ -1,0 +1,21 @@
+name: Contracts Control Plane Security
+
+on:
+  pull_request:
+    paths:
+      - 'src/index.ts'
+      - 'src/endpoints/contracts.ts'
+      - 'scripts/check-contracts-control.py'
+      - '.github/workflows/deploy.yml'
+      - '.github/workflows/contracts-control-security.yml'
+  workflow_dispatch:
+
+jobs:
+  checker-self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Contracts authorization checker self-test
+        run: python3 scripts/check-contracts-control.py --self-test
+      - name: Python syntax check
+        run: python3 -m py_compile scripts/check-contracts-control.py

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,46 @@ jobs:
       - name: Run tests
         run: npx vitest run --config tests/vitest.config.mts 2>/dev/null || echo "Tests skipped (no test DB in CI)"
 
+      - name: Security gate — contracts control plane authorization
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import sys
+
+          index = Path("src/index.ts").read_text(encoding="utf-8")
+          contracts = Path("src/endpoints/contracts.ts").read_text(encoding="utf-8")
+
+          mount = 'app.route("/api/contracts", contracts);'
+          if mount not in index:
+              print("::error::Expected /api/contracts mount was not found; review routing before deployment.")
+              sys.exit(1)
+
+          before_mount = index.split(mount, 1)[0]
+          has_route_gate = (
+              'app.use("/api/contracts/*"' in before_mount
+              and "DARCLOUD_CONTRACTS_READ_TOKEN" in before_mount
+              and "DARCLOUD_CONTRACTS_MUTATION_TOKEN" in before_mount
+          )
+
+          mutation_markers = [
+              'contracts.post("/companies/seed"',
+              'contracts.post("/sign"',
+              'contracts.post("/seed-all"',
+              'contracts.post("/legal/file-all"',
+              'contracts.post("/legal/protect-ip"',
+              'contracts.post("/bootstrap"',
+          ]
+          has_mutations = any(marker in contracts for marker in mutation_markers)
+
+          if has_mutations and not has_route_gate:
+              print("::error::Deployment blocked: /api/contracts contains D1-mutating contract/legal/IP handlers without the required fail-closed read/mutation authorization boundary.")
+              print("Remediate issue #38 before deploying this Worker.")
+              sys.exit(1)
+
+          print("Contracts control-plane deployment gate passed.")
+          PY
+
       - name: Apply D1 Migrations
         run: echo "y" | npx wrangler d1 migrations apply DB --remote
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,44 +28,7 @@ jobs:
         run: npx vitest run --config tests/vitest.config.mts 2>/dev/null || echo "Tests skipped (no test DB in CI)"
 
       - name: Security gate — contracts control plane authorization
-        shell: bash
-        run: |
-          python3 - <<'PY'
-          from pathlib import Path
-          import sys
-
-          index = Path("src/index.ts").read_text(encoding="utf-8")
-          contracts = Path("src/endpoints/contracts.ts").read_text(encoding="utf-8")
-
-          mount = 'app.route("/api/contracts", contracts);'
-          if mount not in index:
-              print("::error::Expected /api/contracts mount was not found; review routing before deployment.")
-              sys.exit(1)
-
-          before_mount = index.split(mount, 1)[0]
-          has_route_gate = (
-              'app.use("/api/contracts/*"' in before_mount
-              and "DARCLOUD_CONTRACTS_READ_TOKEN" in before_mount
-              and "DARCLOUD_CONTRACTS_MUTATION_TOKEN" in before_mount
-          )
-
-          mutation_markers = [
-              'contracts.post("/companies/seed"',
-              'contracts.post("/sign"',
-              'contracts.post("/seed-all"',
-              'contracts.post("/legal/file-all"',
-              'contracts.post("/legal/protect-ip"',
-              'contracts.post("/bootstrap"',
-          ]
-          has_mutations = any(marker in contracts for marker in mutation_markers)
-
-          if has_mutations and not has_route_gate:
-              print("::error::Deployment blocked: /api/contracts contains D1-mutating contract/legal/IP handlers without the required fail-closed read/mutation authorization boundary.")
-              print("Remediate issue #38 before deploying this Worker.")
-              sys.exit(1)
-
-          print("Contracts control-plane deployment gate passed.")
-          PY
+        run: python3 scripts/check-contracts-control.py
 
       - name: Apply D1 Migrations
         run: echo "y" | npx wrangler d1 migrations apply DB --remote

--- a/scripts/check-contracts-control.py
+++ b/scripts/check-contracts-control.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Fail closed when the contracts/DarLaw control plane lacks its auth boundary."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+MOUNT = 'app.route("/api/contracts", contracts);'
+MUTATION_MARKERS = (
+    'contracts.post("/companies/seed"',
+    'contracts.post("/sign"',
+    'contracts.post("/seed-all"',
+    'contracts.post("/legal/file-all"',
+    'contracts.post("/legal/protect-ip"',
+    'contracts.post("/bootstrap"',
+)
+
+
+def evaluate(index: str, contracts: str) -> tuple[bool, str]:
+    if MOUNT not in index:
+        return False, "Expected /api/contracts mount was not found; routing requires security review."
+
+    before_mount = index.split(MOUNT, 1)[0]
+    has_mutations = any(marker in contracts for marker in MUTATION_MARKERS)
+    has_route_gate = (
+        'app.use("/api/contracts/*"' in before_mount
+        and "DARCLOUD_CONTRACTS_READ_TOKEN" in before_mount
+        and "DARCLOUD_CONTRACTS_MUTATION_TOKEN" in before_mount
+    )
+
+    if has_mutations and not has_route_gate:
+        return False, (
+            "/api/contracts contains D1-mutating contract/legal/IP handlers without "
+            "the required fail-closed read/mutation authorization boundary."
+        )
+    return True, "Contracts control-plane deployment gate passed."
+
+
+def self_test() -> int:
+    vulnerable_index = f'const app = 1;\n{MOUNT}\n'
+    protected_index = (
+        'app.use("/api/contracts/*", async () => {{}});\n'
+        'const DARCLOUD_CONTRACTS_READ_TOKEN = "configured-at-runtime";\n'
+        'const DARCLOUD_CONTRACTS_MUTATION_TOKEN = "configured-at-runtime";\n'
+        f'{MOUNT}\n'
+    )
+    mutations = 'contracts.post("/sign", async () => {{}});\n'
+
+    ok, _ = evaluate(vulnerable_index, mutations)
+    if ok:
+        print("self-test failed: vulnerable sample was not blocked", file=sys.stderr)
+        return 1
+
+    ok, _ = evaluate(protected_index, mutations)
+    if not ok:
+        print("self-test failed: protected sample was blocked", file=sys.stderr)
+        return 1
+
+    ok, _ = evaluate("const app = 1;", mutations)
+    if ok:
+        print("self-test failed: unexpected routing change was not blocked", file=sys.stderr)
+        return 1
+
+    print("contracts control-plane checker self-test passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    index = Path("src/index.ts").read_text(encoding="utf-8")
+    contracts = Path("src/endpoints/contracts.ts").read_text(encoding="utf-8")
+    ok, message = evaluate(index, contracts)
+    if not ok:
+        print(f"::error::{message}")
+        print("Remediate issue #38 before deploying this Worker.")
+        return 1
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Defense-in-depth containment for #38.

This PR adds a fail-closed checker to `.github/workflows/deploy.yml`: if `/api/contracts` still contains D1-mutating contract/legal/IP handlers without the expected read/mutation authorization boundary ahead of route dispatch, the GitHub Actions deploy job exits before D1 migrations or `wrangler deploy`.

The checker has a dedicated PR workflow and its synthetic self-test passed on the current head.

**Important:** this PR is intentionally draft and must not be treated as complete deployment containment. Safe testing revealed an alternate Cloudflare native Git-integration path that builds/deploys PR-head commits independently of `.github/workflows/deploy.yml`; that trust-boundary gap is tracked in #40. `darcloud-www` was confirmed preview-only for this PR head, while `sector-gaming` also reported a successful Cloudflare deployment without enough GitHub-side evidence to classify its target. Do not rely on this GitHub Actions gate until #40 is resolved or Cloudflare is proven to enforce equivalent policy.

No Cloudflare secret, D1 row, customer record, payment, wallet, or application runtime source is changed by this PR.