### PR TITLE
Security: authenticate DarCloud backup registry control plane

### DIFF
--- a/.github/workflows/backups-control-plane-security.yml
+++ b/.github/workflows/backups-control-plane-security.yml
@@ -1,0 +1,32 @@
+name: Backup Control Plane Security
+
+on:
+  pull_request:
+    paths:
+      - 'src/endpoints/backups/**'
+      - 'tests/backups-control-policy.test.js'
+      - 'tests/backups-control-authz.behavior.mjs'
+      - '.github/workflows/backups-control-plane-security.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backups-control-plane-security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Static authorization regression
+        run: node tests/backups-control-policy.test.js
+      - name: Synthetic authorization behavior
+        run: node --experimental-strip-types tests/backups-control-authz.behavior.mjs
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: TypeScript check
+        run: npx tsc --noEmit

--- a/src/endpoints/backups/router.ts
+++ b/src/endpoints/backups/router.ts
@@ -5,8 +5,33 @@ import { BackupCreate } from "./backupCreate";
 import { BackupRead } from "./backupRead";
 import { BackupUpdate } from "./backupUpdate";
 import { BackupDelete } from "./backupDelete";
+import { authorizeBackupRequest } from "./security";
 
-export const backupsRouter = fromHono(new Hono());
+export const backupsRouter = fromHono(new Hono<{ Bindings: Env }>());
+
+// Backup inventory is recovery control-plane data. Authenticate before any D1-backed
+// list/read/create/update/delete handler executes, and separate read-only authority
+// from mutation authority.
+backupsRouter.use("*", async (c, next) => {
+  const env = c.env as Env & {
+    DARCLOUD_BACKUPS_READ_TOKEN?: string;
+    DARCLOUD_BACKUPS_MUTATION_TOKEN?: string;
+  };
+
+  const authorization = await authorizeBackupRequest(
+    c.req.method,
+    c.req.header("Authorization"),
+    env.DARCLOUD_BACKUPS_READ_TOKEN,
+    env.DARCLOUD_BACKUPS_MUTATION_TOKEN,
+  );
+
+  if (!authorization.ok) {
+    return c.json({ success: false, error: authorization.error }, authorization.status);
+  }
+
+  await next();
+  c.res.headers.set("Cache-Control", "no-store");
+});
 
 backupsRouter.get("/", BackupList);
 backupsRouter.post("/", BackupCreate);

--- a/src/endpoints/backups/security.ts
+++ b/src/endpoints/backups/security.ts
@@ -1,0 +1,80 @@
+const MIN_CONTROL_TOKEN_LENGTH = 32;
+
+export type BackupAuthorizationResult =
+  | { ok: true; scope: "read" | "mutation" }
+  | { ok: false; status: 401 | 403 | 503; error: string };
+
+function configuredToken(value: unknown): string | null {
+  return typeof value === "string" && value.length >= MIN_CONTROL_TOKEN_LENGTH
+    ? value
+    : null;
+}
+
+function bearerToken(header: string | undefined): string | null {
+  if (!header?.startsWith("Bearer ")) return null;
+  const token = header.slice(7).trim();
+  return token.length > 0 ? token : null;
+}
+
+async function digest(value: string): Promise<Uint8Array> {
+  const bytes = new TextEncoder().encode(value);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+}
+
+async function secureEqual(left: string, right: string): Promise<boolean> {
+  const [a, b] = await Promise.all([digest(left), digest(right)]);
+  let mismatch = a.length ^ b.length;
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    mismatch |= (a[i] || 0) ^ (b[i] || 0);
+  }
+  return mismatch === 0;
+}
+
+export async function authorizeBackupRequest(
+  method: string,
+  authorizationHeader: string | undefined,
+  readTokenValue: unknown,
+  mutationTokenValue: unknown,
+): Promise<BackupAuthorizationResult> {
+  const readToken = configuredToken(readTokenValue);
+  const mutationToken = configuredToken(mutationTokenValue);
+
+  if (!readToken || !mutationToken) {
+    return {
+      ok: false,
+      status: 503,
+      error: "Backup registry authorization is not configured",
+    };
+  }
+
+  if (await secureEqual(readToken, mutationToken)) {
+    return {
+      ok: false,
+      status: 503,
+      error: "Backup registry read and mutation credentials must be distinct",
+    };
+  }
+
+  const supplied = bearerToken(authorizationHeader);
+  if (!supplied) {
+    return { ok: false, status: 401, error: "Authorization required" };
+  }
+
+  const isRead = method === "GET" || method === "HEAD";
+  if (isRead) {
+    if (await secureEqual(supplied, readToken)) {
+      return { ok: true, scope: "read" };
+    }
+    if (await secureEqual(supplied, mutationToken)) {
+      return { ok: true, scope: "mutation" };
+    }
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  if (!(await secureEqual(supplied, mutationToken))) {
+    return { ok: false, status: 403, error: "Forbidden" };
+  }
+
+  return { ok: true, scope: "mutation" };
+}

--- a/tests/backups-control-authz.behavior.mjs
+++ b/tests/backups-control-authz.behavior.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+const { authorizeBackupRequest } = await import('../src/endpoints/backups/security.ts');
+
+const readToken = 'r'.repeat(40);
+const mutationToken = 'm'.repeat(40);
+
+let result = await authorizeBackupRequest('GET', undefined, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 401);
+
+result = await authorizeBackupRequest('GET', 'Bearer wrong', readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeBackupRequest('GET', `Bearer ${readToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'read' });
+
+result = await authorizeBackupRequest('GET', `Bearer ${mutationToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'mutation' });
+
+result = await authorizeBackupRequest('POST', `Bearer ${readToken}`, readToken, mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 403);
+
+result = await authorizeBackupRequest('PUT', `Bearer ${mutationToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'mutation' });
+
+result = await authorizeBackupRequest('DELETE', `Bearer ${mutationToken}`, readToken, mutationToken);
+assert.deepEqual(result, { ok: true, scope: 'mutation' });
+
+result = await authorizeBackupRequest('GET', `Bearer ${readToken}`, 'weak', mutationToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+result = await authorizeBackupRequest('POST', `Bearer ${mutationToken}`, readToken, undefined);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+const sharedToken = 's'.repeat(40);
+result = await authorizeBackupRequest('GET', `Bearer ${sharedToken}`, sharedToken, sharedToken);
+assert.equal(result.ok, false);
+assert.equal(result.status, 503);
+
+console.log('backup registry authorization behavior: PASS');

--- a/tests/backups-control-policy.test.js
+++ b/tests/backups-control-policy.test.js
@@ -1,0 +1,24 @@
+const fs = require('node:fs');
+const assert = require('node:assert/strict');
+
+const router = fs.readFileSync('src/endpoints/backups/router.ts', 'utf8');
+const security = fs.readFileSync('src/endpoints/backups/security.ts', 'utf8');
+
+const authGate = router.indexOf('backupsRouter.use("*"');
+const firstRoute = router.indexOf('backupsRouter.get("/"');
+
+assert(authGate >= 0, 'backup authorization gate must exist');
+assert(firstRoute >= 0, 'backup routes must exist');
+assert(authGate < firstRoute, 'authorization gate must precede every backup route');
+assert(router.includes('authorizeBackupRequest('), 'router must invoke backup authorization policy');
+assert(router.includes('DARCLOUD_BACKUPS_READ_TOKEN'), 'read credential must be server-managed');
+assert(router.includes('DARCLOUD_BACKUPS_MUTATION_TOKEN'), 'mutation credential must be server-managed');
+assert(router.includes('Cache-Control", "no-store"'), 'authenticated backup responses must be non-cacheable');
+assert(security.includes('MIN_CONTROL_TOKEN_LENGTH = 32'), 'weak server credentials must fail closed');
+assert(security.includes('status: 503'), 'missing/unsafe server auth configuration must fail closed');
+assert(security.includes('status: 401'), 'missing bearer credentials must be rejected');
+assert(security.includes('status: 403'), 'incorrect/insufficient credentials must be rejected');
+assert(security.includes('crypto.subtle.digest("SHA-256"'), 'credential comparison must avoid direct plaintext equality');
+assert(security.includes('read and mutation credentials must be distinct'), 'read/mutation credentials must not collapse into one shared secret');
+
+console.log('backup control-plane authorization regression: PASS');


### PR DESCRIPTION
Closes the source-level broken-access-control gap reported in #43 by adding a fail-closed authorization boundary before every `/backups` route.

### What changes
- adds separate server-managed read and mutation credentials;
- requires both credentials to be at least 32 characters and distinct;
- permits read credentials only on GET/HEAD;
- permits mutation credentials for both reads and state changes;
- returns 503 for unsafe/missing server auth configuration, 401 for missing caller auth, and 403 for invalid/insufficient caller auth;
- applies the middleware before any Chanfana D1 backup handler;
- marks authenticated responses `Cache-Control: no-store`;
- adds provider-free synthetic behavior and static route-order regressions plus TypeScript CI.

### Safety / deployment gate
This PR is intentionally **draft** and does not configure or expose any credential. Production must first provision managed `DARCLOUD_BACKUPS_READ_TOKEN` and `DARCLOUD_BACKUPS_MUTATION_TOKEN` values and migrate legitimate backup agents/operators. Merging/deploying without those values is expected to fail closed.

No production D1 row, backup object, mesh node, secret, payment, wallet, or customer record was accessed or modified while preparing this change.